### PR TITLE
Set sticky header prop from false to true

### DIFF
--- a/src/views/SongView.vue
+++ b/src/views/SongView.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { lxDateUtils, LxForm, LxLoaderView, LxRow, LxSection, LxToolbar } from '@wntr/lx-ui';
+import { lxDateUtils, LxForm, LxLoaderView, LxRow, LxSection } from '@wntr/lx-ui';
 import { computed, onMounted, onUnmounted, ref } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { useRoute, useRouter } from 'vue-router';
@@ -447,7 +447,7 @@ onUnmounted(() => {
 <template>
   <LxLoaderView :loading="loading">
     <LxForm
-      :sticky-header="false"
+      :sticky-header="true"
       :show-footer="false"
       :action-definitions="formActions"
       @button-click="actionClicked"


### PR DESCRIPTION
While browsing through long songs, the `LxForm` header stays at the top of the page, which makes it difficult to interact with the form
I changed the `sticky-header` prop to `true`, and now form header always stays at the top of the screen while scrolling, making the form functionality accessible from anywhere.

P.S. also removed unused import