### PR TITLE
QoL feature - add transpose buttons to song view footer

### DIFF
--- a/src/locales/lv.json
+++ b/src/locales/lv.json
@@ -110,7 +110,8 @@
         "description": "Samazināt burtu izmēru dziesmas tekstā"
       },
       "transposeDisabled": "Transponēšana ir atspējota, jo dziesmas tekstā nav atrodami akordi",
-      "audioNotSupported": "Jūsu pārlūks neatbalsta audio"
+      "audioNotSupported": "Jūsu pārlūks neatbalsta audio",
+      "transposeHeader": "Transponēt ({offset})" 
     },
     "akordiArtistLetter": {
       "title": "Mākslinieku katalogs A-Z",

--- a/src/main.js
+++ b/src/main.js
@@ -47,6 +47,7 @@ import '@wntr/lx-ui/dist/styles/lx-shell-grid.css';
 import '@wntr/lx-ui/dist/styles/lx-shell-grid-public.css';
 import '@wntr/lx-ui/dist/styles/lx-forms-grid.css';
 import '@wntr/lx-ui/dist/styles/lx-treelist.css';
+import '@wntr/lx-ui/dist/styles/lx-stack.css';
 
 import '@/assets/styles.css';
 import '@/assets/lx-pt-akordi.css';

--- a/src/views/SongView.vue
+++ b/src/views/SongView.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { lxDateUtils, LxForm, LxLoaderView, LxRow, LxSection } from '@wntr/lx-ui';
+import { lxDateUtils, LxForm, LxLoaderView, LxRow, LxSection, LxStack, LxButton } from '@wntr/lx-ui';
 import { computed, onMounted, onUnmounted, ref } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { useRoute, useRouter } from 'vue-router';
@@ -448,12 +448,21 @@ onUnmounted(() => {
   <LxLoaderView :loading="loading">
     <LxForm
       :sticky-header="true"
-      :show-footer="false"
+      :show-footer="hasChords"
       :action-definitions="formActions"
       @button-click="actionClicked"
       :show-post-header-info="true"
       kind="compact"
     >
+      <template #footer>
+        <LxStack orientation="horizontal"  horizontal-alignment="leading" vertical-alignment="center">
+          <label class="lx-data">{{ $t('pages.akordiSongView.transposeHeader', { offset: bodyTransposedIndex > 0 ? `+${bodyTransposedIndex}` : bodyTransposedIndex }) }}</label>
+          <LxStack orientation="horizontal" horizontal-alignment="leading" vertical-alignment="center">
+            <LxButton kind="ghost" variant="icon-only" icon="move-up" :label="$t('pages.akordiSongView.transposeUp.label')" @click="actionClicked('transposeUp')" />
+            <LxButton kind="ghost" variant="icon-only" icon="move-down" :label="$t('pages.akordiSongView.transposeDown.label')" @click="actionClicked('transposeDown')" />
+          </LxStack>
+        </LxStack>
+      </template>
       <template #post-header>{{ item.createdAt }} </template>
       <template #post-header-info>
         <LxRow :label="$t('song.createdAt')">


### PR DESCRIPTION
QoL improvement for serial transposers, current implementation under dropdown is very inconvenient when doing more than 1 step. 
Also shows the current step now, which is pretty standard on other chord sites and been a major pain here.
Footer remains hidden if song does not support transposing.

Maybe could also add a toggle somewhere, for those who do not care about it (remembered within session or kept in memory until refresh).

![image](https://github.com/user-attachments/assets/0cafc2e9-789b-4bed-92f0-219bb32ab492)
