### PR TITLE
Fix lyrics not visible at end of long text line

### DIFF
--- a/src/views/SongView.vue
+++ b/src/views/SongView.vue
@@ -735,7 +735,7 @@ onUnmounted(() => {
         </div>
       </LxSection>
       <LxSection id="body">
-        <LxRow>
+        <LxRow :style="{ overflow: 'visible !important' }">
           <p class="pre" v-html="item.bodyWithMarkup" :style="{ fontSize: fontSize + 'em' }"></p>
         </LxRow>
       </LxSection>


### PR DESCRIPTION
The problem is that one of the parents has `overflow: hidden` which cuts off lyrics. Assuming the LX framework needs further considerations regarding this. Creating a temporary fix, because I want to see lyrics, when I sing my songs.

Screenshots:
Before:
<img width="3167" height="1765" alt="Screenshot 2025-08-31 143922" src="https://github.com/user-attachments/assets/312b009d-ca0e-478e-b4d3-04312a1b17cf" />
After:
<img width="3190" height="1776" alt="Screenshot 2025-08-31 151714" src="https://github.com/user-attachments/assets/0d94e89c-d114-447b-8d64-f62fd948e1f5" />