### PR TITLE
feat: play-along mode on the song page

### DIFF
--- a/src/components/ChordPlayer.vue
+++ b/src/components/ChordPlayer.vue
@@ -1,0 +1,466 @@
+<script setup>
+/**
+ * Plays a YouTube video and shows, at a glance, which chord to play now, how
+ * much of it is left, and what comes next.
+ *
+ * Laying *every* chord of the whole song on one proportional track collapses a
+ * real song's dozens of chords into an unreadable strip. Instead we now:
+ *   - promote the current chord into a focal HUD with a depleting bar showing
+ *     the time left before it changes, plus the upcoming chord + countdown;
+ *   - render the chords within a fixed time span (VIEW_SPAN_SEC) on a track that
+ *     scrolls continuously under a fixed playhead, so the current chord sits at
+ *     the playhead, the upcoming progression is always visible ahead of it, and
+ *     nothing jumps when the chord changes.
+ * Custom markup (iframe + timeline) lives here in a component, per LX UI
+ * conventions.
+ */
+import { computed, onBeforeUnmount, ref, shallowRef, watch } from 'vue';
+import { useI18n } from 'vue-i18n';
+
+import { activeSegmentIndex, nextSegment, segmentProgress, youtubeId } from '@/utils/chordSync';
+
+const { t: $t } = useI18n();
+
+const props = defineProps({
+  videoUrl: { type: String, default: '' },
+  segments: { type: Array, default: () => [] },
+  duration: { type: Number, default: 0 },
+});
+
+// Fixed-playhead scroller. The playhead stays put and the chord strip scrolls
+// continuously under it based on playback time, so nothing jumps when the chord
+// changes and the whole upcoming progression stays visible to the right.
+//   VIEW_SPAN_SEC  — seconds of the song visible across the track width
+//   LEAD_FRACTION  — playhead position from the left (a little past context on
+//                    the left, the rest is look-ahead)
+const VIEW_SPAN_SEC = 20;
+const LEAD_FRACTION = 0.15;
+
+const mount = ref(null);
+const currentTime = ref(0);
+const ready = shallowRef(false);
+let player = null;
+let tick = null;
+
+const videoId = computed(() => youtubeId(props.videoUrl));
+const activeIndex = computed(() => activeSegmentIndex(props.segments, currentTime.value));
+const activeSeg = computed(() =>
+  activeIndex.value >= 0 ? props.segments[activeIndex.value] || null : null
+);
+const activeChord = computed(() => activeSeg.value?.label || '');
+const hasStarted = computed(() => activeIndex.value >= 0);
+const isLast = computed(() => activeIndex.value === props.segments.length - 1);
+
+// The chord coming up next. Before the first chord starts (nothing active yet)
+// we surface the opening chord so the very first change is still announced.
+const upcoming = computed(() => {
+  if (activeIndex.value < 0) {
+    return props.segments[0] || null;
+  }
+  return nextSegment(props.segments, activeIndex.value);
+});
+
+// Seconds until the upcoming chord begins (== time left on the current chord in
+// the normal case, since segments are contiguous).
+const timeToNext = computed(() => {
+  if (!upcoming.value) {
+    return 0;
+  }
+  return Math.max(0, upcoming.value.start - currentTime.value);
+});
+
+// Seconds left on the currently-playing chord, and the fraction already played
+// (drives the depleting HUD bar).
+const currentRemaining = computed(() =>
+  activeSeg.value ? Math.max(0, activeSeg.value.end - currentTime.value) : 0
+);
+const currentProgress = computed(() =>
+  segmentProgress(props.segments, activeIndex.value, currentTime.value)
+);
+// Bar fill = remaining time, so it visibly depletes as the change approaches.
+const remainingStyle = computed(() => ({
+  width: `${(1 - currentProgress.value) * 100}%`,
+}));
+
+// Start of the visible time viewport. Clamped at 0 so the intro doesn't scroll
+// in from empty space before playback; once past the lead-in the viewport
+// tracks currentTime so the strip scrolls smoothly and the playhead is fixed.
+const viewStart = computed(() => Math.max(0, currentTime.value - LEAD_FRACTION * VIEW_SPAN_SEC));
+
+// Only the chords overlapping the viewport are rendered; the rest are off-track.
+const visibleSegments = computed(() => {
+  const start = viewStart.value;
+  const end = start + VIEW_SPAN_SEC;
+  const out = [];
+  for (let i = 0; i < props.segments.length; i += 1) {
+    const seg = props.segments[i];
+    if (seg.end >= start && seg.start <= end) {
+      out.push({ seg, index: i });
+    }
+  }
+  return out;
+});
+
+// Position/size a chord block as a percentage of the visible time span, so its
+// width stays proportional to its duration and it scrolls left as time passes.
+function blockStyle(seg) {
+  return {
+    left: `${((seg.start - viewStart.value) / VIEW_SPAN_SEC) * 100}%`,
+    width: `${((seg.end - seg.start) / VIEW_SPAN_SEC) * 100}%`,
+  };
+}
+
+// The playhead is effectively fixed once past the lead-in (currentTime -
+// viewStart == LEAD_FRACTION * span); during the lead-in it rides from the left
+// edge up to that resting position.
+const playheadStyle = computed(() => {
+  const pct = ((currentTime.value - viewStart.value) / VIEW_SPAN_SEC) * 100;
+  return { left: `${Math.min(100, Math.max(0, pct))}%` };
+});
+
+function fmt(seconds) {
+  return `${seconds.toFixed(1)}${$t('pages.playAlong.seconds')}`;
+}
+
+// Load the YouTube IFrame Player API once; resolve when window.YT is ready.
+function loadApi() {
+  return new Promise((resolve) => {
+    if (window.YT && window.YT.Player) {
+      resolve(window.YT);
+      return;
+    }
+    const previous = window.onYouTubeIframeAPIReady;
+    window.onYouTubeIframeAPIReady = () => {
+      if (typeof previous === 'function') {
+        previous();
+      }
+      resolve(window.YT);
+    };
+    if (!document.querySelector('script[data-yt-iframe-api]')) {
+      const script = document.createElement('script');
+      script.src = 'https://www.youtube.com/iframe_api';
+      script.async = true;
+      script.dataset.ytIframeApi = 'true';
+      document.head.appendChild(script);
+    }
+  });
+}
+
+function stopTicking() {
+  if (tick) {
+    clearInterval(tick);
+    tick = null;
+  }
+}
+
+function startTicking() {
+  stopTicking();
+  // 150 ms is smooth enough to track chord changes without busy-looping.
+  tick = setInterval(() => {
+    if (player && typeof player.getCurrentTime === 'function') {
+      currentTime.value = player.getCurrentTime();
+    }
+  }, 150);
+}
+
+async function build() {
+  if (!videoId.value) {
+    return;
+  }
+  const YT = await loadApi();
+  if (!mount.value) {
+    return;
+  }
+  player = new YT.Player(mount.value, {
+    videoId: videoId.value,
+    playerVars: { rel: 0, modestbranding: 1, playsinline: 1 },
+    events: {
+      onReady: () => {
+        ready.value = true;
+      },
+      onStateChange: (event) => {
+        // 1 = playing → track time; anything else → stop the ticker.
+        if (event.data === 1) {
+          startTicking();
+        } else {
+          stopTicking();
+        }
+      },
+    },
+  });
+}
+
+function seek(seg) {
+  if (player && typeof player.seekTo === 'function') {
+    player.seekTo(seg.start, true);
+    player.playVideo();
+    currentTime.value = seg.start;
+  }
+}
+
+watch(
+  videoId,
+  (id) => {
+    if (!id) {
+      return;
+    }
+    if (player && typeof player.loadVideoById === 'function') {
+      player.loadVideoById(id);
+    } else {
+      build();
+    }
+  },
+  { immediate: true }
+);
+
+onBeforeUnmount(() => {
+  stopTicking();
+  if (player && typeof player.destroy === 'function') {
+    player.destroy();
+    player = null;
+  }
+});
+</script>
+
+<template>
+  <div class="chord-player">
+    <div class="chord-player-stage">
+      <div ref="mount" class="chord-player-frame"></div>
+    </div>
+
+    <!-- Heads-up display: current chord + time left, and what's next. -->
+    <div class="chord-player-hud">
+      <div class="chord-now" aria-live="polite">
+        <span class="chord-now-label">{{ $t('pages.playAlong.nowPlaying') }}</span>
+        <div class="chord-now-body">
+          <span class="chord-now-chord">{{ activeChord || '—' }}</span>
+          <span v-if="hasStarted" class="chord-now-remaining">{{ fmt(currentRemaining) }}</span>
+        </div>
+        <div class="chord-now-bar" :aria-hidden="true">
+          <div class="chord-now-bar-fill" :style="remainingStyle"></div>
+        </div>
+      </div>
+
+      <div class="chord-next">
+        <template v-if="upcoming && !isLast">
+          <span class="chord-next-label">{{ $t('pages.playAlong.nextChord') }}</span>
+          <span class="chord-next-chord">{{ upcoming.label }}</span>
+          <span class="chord-next-time"
+            >{{ $t('pages.playAlong.changesIn') }} {{ fmt(timeToNext) }}</span
+          >
+        </template>
+        <template v-else-if="isLast">
+          <span class="chord-next-label">{{ $t('pages.playAlong.nextChord') }}</span>
+          <span class="chord-next-end">{{ $t('pages.playAlong.songEnd') }}</span>
+        </template>
+      </div>
+    </div>
+
+    <!-- Scrolling chord track: the chords overlapping the visible time span are
+         laid out proportionally and scroll left under a fixed playhead as the
+         song plays, so the current chord sits at the playhead and the upcoming
+         progression is always visible ahead of it. -->
+    <div class="chord-player-track">
+      <!-- Rendered as role=button divs (not <button>) so the global LX UI
+           button sizing doesn't clamp the proportional width to a min square.
+           The visible text is the label only, so the accessible name matches
+           the chord exactly. -->
+      <div
+        v-for="item in visibleSegments"
+        :key="item.index"
+        class="chord-block"
+        role="button"
+        tabindex="0"
+        :class="{ 'is-active': item.index === activeIndex, 'is-past': item.index < activeIndex }"
+        :style="blockStyle(item.seg)"
+        :title="`${item.seg.label} · ${fmt(item.seg.end - item.seg.start)}`"
+        @click="seek(item.seg)"
+        @keydown.enter.prevent="seek(item.seg)"
+        @keydown.space.prevent="seek(item.seg)"
+      >
+        <span class="chord-block-label">{{ item.seg.label }}</span>
+      </div>
+      <div class="chord-player-playhead" :style="playheadStyle"></div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.chord-player {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  max-width: 100%;
+}
+.chord-player-stage {
+  position: relative;
+  width: 100%;
+  max-width: 720px;
+  aspect-ratio: 16 / 9;
+}
+.chord-player-frame,
+.chord-player-frame :deep(iframe) {
+  width: 100%;
+  height: 100%;
+  border: 0;
+  border-radius: 8px;
+}
+
+/* Heads-up display ------------------------------------------------------- */
+.chord-player-hud {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: stretch;
+  gap: 0.75rem;
+  max-width: 100%;
+}
+.chord-now,
+.chord-next {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  padding: 0.75rem 1rem;
+  /* --color-region-2 is the subtle surface that reads on the white content
+     area; --color-chrome is a real border colour (unlike --color-input-border,
+     which is a 4-value underline shorthand). */
+  border: 1px solid var(--color-chrome, #e0e0e0);
+  border-radius: 8px;
+  background: var(--color-region-2, #eee);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.06);
+  box-sizing: border-box;
+}
+.chord-now {
+  flex: 2 1 14rem;
+  min-width: 0;
+}
+.chord-next {
+  flex: 1 1 9rem;
+  min-width: 0;
+  justify-content: center;
+}
+.chord-now-label,
+.chord-next-label {
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--color-label, #757575);
+}
+.chord-now-body {
+  display: flex;
+  align-items: baseline;
+  gap: 0.75rem;
+}
+.chord-now-chord {
+  font-size: 2.75rem;
+  line-height: 1;
+  font-weight: 700;
+  font-family: monospace;
+  color: var(--color-brand, #18bc9c);
+}
+.chord-now-remaining {
+  font-size: 1rem;
+  font-variant-numeric: tabular-nums;
+  color: var(--color-label, #757575);
+}
+.chord-now-bar {
+  width: 100%;
+  height: 6px;
+  border-radius: 999px;
+  background: rgba(0, 0, 0, 0.14);
+  overflow: hidden;
+}
+.chord-now-bar-fill {
+  height: 100%;
+  border-radius: 999px;
+  background: var(--color-brand, #18bc9c);
+  transition: width 0.15s linear;
+}
+.chord-next-chord {
+  font-size: 1.75rem;
+  line-height: 1.1;
+  font-weight: 700;
+  font-family: monospace;
+  color: var(--color-data, #2b2b2b);
+}
+.chord-next-time {
+  font-size: 0.85rem;
+  font-variant-numeric: tabular-nums;
+  color: var(--color-label, #757575);
+}
+.chord-next-end {
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: var(--color-label, #757575);
+}
+
+/* Windowed track --------------------------------------------------------- */
+.chord-player-track {
+  position: relative;
+  width: 100%;
+  height: 3.75rem;
+  background: var(--color-region-2, #eee);
+  border: 1px solid var(--color-chrome, #e0e0e0);
+  border-radius: 8px;
+  overflow: hidden;
+  box-sizing: border-box;
+}
+.chord-block {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  box-sizing: border-box;
+  min-width: 1.75rem;
+  border-right: 1px solid var(--color-chrome, #e0e0e0);
+  background: transparent;
+  color: var(--color-data, #333);
+  font-family: monospace;
+  font-weight: 600;
+  cursor: pointer;
+  overflow: hidden;
+  white-space: nowrap;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  /* left transitions so the strip scrolls smoothly between the 150 ms time
+     samples instead of stepping; background-color for the active highlight. */
+  transition: left 0.15s linear, background-color 0.15s ease;
+}
+.chord-block:focus-visible {
+  outline: 2px solid var(--color-brand, #18bc9c);
+  outline-offset: -2px;
+}
+.chord-block-label {
+  padding: 0 0.35rem;
+}
+.chord-block.is-past {
+  opacity: 0.4;
+}
+.chord-block.is-active {
+  background: var(--color-brand, #18bc9c);
+  color: var(--color-region, #fff);
+  font-weight: 700;
+}
+.chord-player-playhead {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: 3px;
+  /* Not the brand colour — the active chord block is brand-coloured, so a brand
+     playhead disappears over it. Use the high-contrast data colour with a 1px
+     halo in the surface colour so the line stays crisp over both the track and
+     the active block, in light and dark themes. */
+  background: var(--color-data, #2b2b2b);
+  box-shadow: 0 0 0 1px var(--color-region, #fff);
+  transition: left 0.15s linear;
+  pointer-events: none;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .chord-player-playhead,
+  .chord-now-bar-fill,
+  .chord-block {
+    transition: none;
+  }
+}
+</style>

--- a/src/locales/ee.json
+++ b/src/locales/ee.json
@@ -211,6 +211,7 @@
         },
         "playAlong": {
             "toggle": "Mängi kaasa",
+            "hint": "Esita YouTube video ja jälgi akorde reaalajas.",
             "exit": "Tagasi teksti juurde",
             "nowPlaying": "Praegu kõlab",
             "nextChord": "Järgmine",

--- a/src/locales/ee.json
+++ b/src/locales/ee.json
@@ -209,6 +209,15 @@
             "title": "Esita laul",
             "description": "Siin saate esitada laulu, et see lisataks portaali. Leht on mõeldud ainult eesti lauludele (laulu keelel pole tähtsust). See kontrollitakse ja lisatakse andmebaasi."
         },
+        "playAlong": {
+            "toggle": "Mängi kaasa",
+            "exit": "Tagasi teksti juurde",
+            "nowPlaying": "Praegu kõlab",
+            "nextChord": "Järgmine",
+            "changesIn": "pärast",
+            "songEnd": "Laulu lõpp",
+            "seconds": "s"
+        },
         "akordiSongView": {
             "title": "Akordid.ee laulud",
             "copy": {

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -211,6 +211,7 @@
         },
         "playAlong": {
             "toggle": "Tocar junto",
+            "hint": "Reproduce el vídeo de YouTube y sigue los acordes en tiempo real.",
             "exit": "Volver a la letra",
             "nowPlaying": "Suena ahora",
             "nextChord": "Siguiente",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -209,6 +209,15 @@
             "title": "Enviar canción",
             "description": "Aquí puedes enviar una canción para que se añada al portal. La página está destinada únicamente a canciones españolas (el idioma de la canción no importa). Será revisada y añadida a la base de datos."
         },
+        "playAlong": {
+            "toggle": "Tocar junto",
+            "exit": "Volver a la letra",
+            "nowPlaying": "Suena ahora",
+            "nextChord": "Siguiente",
+            "changesIn": "en",
+            "songEnd": "Fin de la canción",
+            "seconds": "s"
+        },
         "akordiSongView": {
             "title": "Canciones de Akordi.es",
             "copy": {

--- a/src/locales/lt.json
+++ b/src/locales/lt.json
@@ -209,6 +209,15 @@
             "title": "Pateikti dainą",
             "description": "Čia galite pateikti dainą, kad ji būtų pridėta prie portalo. Puslapis skirtas tik lietuviškoms dainoms (dainos kalbai nėra reikšmės). Ji bus patikrinta ir pridėta prie duomenų bazės."
         },
+        "playAlong": {
+            "toggle": "Groti kartu",
+            "exit": "Atgal į tekstą",
+            "nowPlaying": "Dabar skamba",
+            "nextChord": "Kitas",
+            "changesIn": "po",
+            "songEnd": "Dainos pabaiga",
+            "seconds": "s"
+        },
         "akordiSongView": {
             "title": "Akordai.lt dainos",
             "copy": {

--- a/src/locales/lt.json
+++ b/src/locales/lt.json
@@ -211,6 +211,7 @@
         },
         "playAlong": {
             "toggle": "Groti kartu",
+            "hint": "Leisk YouTube vaizdo įrašą ir sek akordus realiu laiku.",
             "exit": "Atgal į tekstą",
             "nowPlaying": "Dabar skamba",
             "nextChord": "Kitas",

--- a/src/locales/lv.json
+++ b/src/locales/lv.json
@@ -209,6 +209,15 @@
             "title": "Iesniegt dziesmu",
             "description": "Šeit jūs varat iesniegt dziesmu, lai tā tiktu pievienota portālā. Lapa paredzēta tikai latviešu dziesmām (dziesmas valodai nav nozīmes). Tā tiks pārbaudīta un pievienota datu bāzei."
         },
+        "playAlong": {
+            "toggle": "Spēlēt līdzi",
+            "exit": "Atpakaļ uz tekstu",
+            "nowPlaying": "Tagad skan",
+            "nextChord": "Nākamais",
+            "changesIn": "pēc",
+            "songEnd": "Dziesmas beigas",
+            "seconds": "s"
+        },
         "akordiSongView": {
             "title": "Akordi.lv dziesmas",
             "copy": {

--- a/src/locales/lv.json
+++ b/src/locales/lv.json
@@ -211,6 +211,7 @@
         },
         "playAlong": {
             "toggle": "Spēlēt līdzi",
+            "hint": "Atskaņo YouTube video un seko akordiem reāllaikā.",
             "exit": "Atpakaļ uz tekstu",
             "nowPlaying": "Tagad skan",
             "nextChord": "Nākamais",

--- a/src/utils/chordSync.js
+++ b/src/utils/chordSync.js
@@ -1,0 +1,106 @@
+// Pure helpers for syncing recognised chord segments to a YouTube player.
+// Kept framework-free so they can be unit-tested without a DOM.
+
+/**
+ * Extract the 11-character YouTube video id from any common URL shape
+ * (watch?v=, youtu.be/, /embed/, /shorts/). Returns '' when none is found.
+ * @param {string} url
+ * @returns {string}
+ */
+export function youtubeId(url) {
+  if (!url) {
+    return '';
+  }
+  const match = String(url).match(/(?:v=|youtu\.be\/|\/embed\/|\/shorts\/)([A-Za-z0-9_-]{11})/);
+  return match ? match[1] : '';
+}
+
+/**
+ * Index of the chord segment active at the given playback time (seconds).
+ * A segment is active for start <= time < end. Once playback passes the last
+ * segment's end we keep the final chord highlighted; before the first start we
+ * return -1 (nothing active yet).
+ * @param {Array<{start:number,end:number}>} segments
+ * @param {number} time
+ * @returns {number}
+ */
+export function activeSegmentIndex(segments, time) {
+  if (!Array.isArray(segments) || segments.length === 0) {
+    return -1;
+  }
+  for (let i = 0; i < segments.length; i += 1) {
+    const seg = segments[i];
+    if (time >= seg.start && time < seg.end) {
+      return i;
+    }
+  }
+  const last = segments[segments.length - 1];
+  return time >= last.end ? segments.length - 1 : -1;
+}
+
+/**
+ * The segment that comes after the active one, or null when there is none
+ * (last segment, empty list, or no segment active yet).
+ * @param {Array<{start:number,end:number,label:string}>} segments
+ * @param {number} activeIndex index returned by activeSegmentIndex
+ * @returns {{start:number,end:number,label:string}|null}
+ */
+export function nextSegment(segments, activeIndex) {
+  if (!Array.isArray(segments) || activeIndex < 0) {
+    return null;
+  }
+  const next = segments[activeIndex + 1];
+  return next || null;
+}
+
+/**
+ * Fraction (0..1) of a segment that has elapsed at the given time. Clamped so
+ * the value never leaves [0, 1] even when time is before the segment starts or
+ * after it ends. Returns 0 for an invalid index or a zero-length segment.
+ * @param {Array<{start:number,end:number}>} segments
+ * @param {number} index
+ * @param {number} time seconds
+ * @returns {number}
+ */
+export function segmentProgress(segments, index, time) {
+  if (!Array.isArray(segments) || index < 0 || index >= segments.length) {
+    return 0;
+  }
+  const seg = segments[index];
+  const span = seg.end - seg.start;
+  if (span <= 0) {
+    return time >= seg.end ? 1 : 0;
+  }
+  const fraction = (time - seg.start) / span;
+  return Math.min(1, Math.max(0, fraction));
+}
+
+/**
+ * A bounded window of segments centred on the active one, so the live timeline
+ * stays legible no matter how many chords the song has. Returns the sliced
+ * segments (with their original indices) plus the window's time span, used to
+ * lay blocks out proportionally *within the window* rather than the whole song.
+ *
+ * When nothing is active yet (activeIndex < 0) the window anchors at the start
+ * so the opening chords are visible. Bounds are clamped at the song's ends.
+ *
+ * @param {Array<{start:number,end:number,label:string}>} segments
+ * @param {number} activeIndex
+ * @param {{before?:number, after?:number}} [opts] chords to keep on each side
+ * @returns {{items: Array<{seg:object, index:number}>, start:number, end:number}}
+ */
+export function segmentWindow(segments, activeIndex, opts = {}) {
+  if (!Array.isArray(segments) || segments.length === 0) {
+    return { items: [], start: 0, end: 0 };
+  }
+  const before = Number.isFinite(opts.before) ? opts.before : 1;
+  const after = Number.isFinite(opts.after) ? opts.after : 5;
+  const anchor = activeIndex < 0 ? 0 : Math.min(activeIndex, segments.length - 1);
+  const lo = Math.max(0, anchor - before);
+  const hi = Math.min(segments.length - 1, anchor + after);
+  const items = [];
+  for (let i = lo; i <= hi; i += 1) {
+    items.push({ seg: segments[i], index: i });
+  }
+  return { items, start: segments[lo].start, end: segments[hi].end };
+}

--- a/src/views/SongView.vue
+++ b/src/views/SongView.vue
@@ -611,9 +611,11 @@ onUnmounted(() => {
           <LxToolbar :noBorders="true">
             <template #leftArea>
               <template v-if="playable">
+                <!-- Labeled (not icon-only) so this flagship action is not
+                     confused with the icon-only auto-scroll play button, which
+                     shares the 'play' glyph at rest. -->
                 <LxButton
-                  kind="ghost"
-                  variant="icon-only"
+                  :kind="playAlong ? 'ghost' : 'primary'"
                   :icon="playAlong ? 'close' : 'play'"
                   :active="playAlong"
                   :label="playAlong ? $t('pages.playAlong.exit') : $t('pages.playAlong.toggle')"

--- a/src/views/SongView.vue
+++ b/src/views/SongView.vue
@@ -20,6 +20,8 @@ import { useRoute, useRouter } from 'vue-router';
 import AbcViewer from '@/components/AbcViewer.vue';
 import { pageview } from 'vue-gtag';
 import ChordSvg from '@/components/ChordSvg.vue';
+import ChordPlayer from '@/components/ChordPlayer.vue';
+import { youtubeId } from '@/utils/chordSync';
 import useAccountPreferencesStore from '@/stores/useAccountPreferencesStore';
 import useAuthStore from '@/stores/useAuthStore';
 import akordiAdminListService from '@/services/songbookService';
@@ -56,6 +58,18 @@ const loading = ref(true);
 const hasChords = ref(false);
 const chords = ref([]);
 const hasAbc = computed(() => item.value.bodyAbc);
+
+// Play-along: derived from the loaded song. youtubeLink is stored as a bare
+// 11-char video id, so expand it to a watch URL that youtubeId() understands.
+// chordTimeline may be null/absent → segments/duration default to empty.
+const videoUrl = computed(() =>
+  item.value.youtubeLink ? `https://www.youtube.com/watch?v=${item.value.youtubeLink}` : ''
+);
+const segments = computed(() => item.value.chordTimeline?.segments ?? []);
+const duration = computed(() => item.value.chordTimeline?.duration ?? 0);
+// A song is playable only with a resolvable video AND at least one chord segment.
+const playable = computed(() => !!youtubeId(videoUrl.value) && segments.value.length > 0);
+const playAlong = ref(false);
 const fontSize = ref(1);
 const offsetFormatted = computed(() => {
   if (bodyTransposedIndex.value > 0) {
@@ -248,8 +262,18 @@ watch(autoScrollerSpeed, (level) => {
   startAutoScroll();
 });
 
+// Toggle play-along. Entering stops the auto-scroller so the two "motion"
+// features don't fight; the toolbar (and its scroll control) is hidden anyway.
+function togglePlayAlong() {
+  playAlong.value = !playAlong.value;
+  if (playAlong.value) {
+    autoScrollerSpeed.value = 0;
+  }
+}
+
 const loadSong = async () => {
   try {
+    playAlong.value = false;
     const songId = akordiService.parseUrl(songUrlParam.value);
     const resp = await akordiService.getSong(songId);
     item.value = resp.data;
@@ -586,65 +610,78 @@ onUnmounted(() => {
         <LxToolbarGroup id="songToolbarGroup">
           <LxToolbar :noBorders="true">
             <template #leftArea>
-              <label class="lx-data toolbar-label">{{
-                $t('pages.akordiSongView.transposeHeader', {
-                  offset: offsetFormatted,
-                })
-              }}</label>
-              <LxButton
-                kind="ghost"
-                variant="icon-only"
-                icon="move-up"
-                :label="$t('pages.akordiSongView.transposeUp.label')"
-                @click="actionClicked('transposeUp')"
-              />
-              <LxButton
-                kind="ghost"
-                variant="icon-only"
-                icon="move-down"
-                :label="$t('pages.akordiSongView.transposeDown.label')"
-                @click="actionClicked('transposeDown')"
-              />
-              <div class="lx-divider"></div>
-              <label class="lx-data toolbar-label">{{
-                $t('pages.akordiSongView.fontUp.label')
-              }}</label>
-              <LxButton
-                kind="ghost"
-                variant="icon-only"
-                icon="zoom-in"
-                :label="$t('pages.akordiSongView.fontUp.label')"
-                @click="actionClicked('fontUp')"
-              />
-              <LxButton
-                kind="ghost"
-                variant="icon-only"
-                icon="zoom-out"
-                :label="$t('pages.akordiSongView.fontDown.label')"
-                @click="actionClicked('fontDown')"
-              />
-              <div class="lx-divider"></div>
+              <template v-if="playable">
+                <LxButton
+                  kind="ghost"
+                  variant="icon-only"
+                  :icon="playAlong ? 'close' : 'play'"
+                  :active="playAlong"
+                  :label="playAlong ? $t('pages.playAlong.exit') : $t('pages.playAlong.toggle')"
+                  @click="togglePlayAlong"
+                />
+                <div class="lx-divider"></div>
+              </template>
+              <template v-if="!playAlong">
+                <label class="lx-data toolbar-label">{{
+                  $t('pages.akordiSongView.transposeHeader', {
+                    offset: offsetFormatted,
+                  })
+                }}</label>
+                <LxButton
+                  kind="ghost"
+                  variant="icon-only"
+                  icon="move-up"
+                  :label="$t('pages.akordiSongView.transposeUp.label')"
+                  @click="actionClicked('transposeUp')"
+                />
+                <LxButton
+                  kind="ghost"
+                  variant="icon-only"
+                  icon="move-down"
+                  :label="$t('pages.akordiSongView.transposeDown.label')"
+                  @click="actionClicked('transposeDown')"
+                />
+                <div class="lx-divider"></div>
+                <label class="lx-data toolbar-label">{{
+                  $t('pages.akordiSongView.fontUp.label')
+                }}</label>
+                <LxButton
+                  kind="ghost"
+                  variant="icon-only"
+                  icon="zoom-in"
+                  :label="$t('pages.akordiSongView.fontUp.label')"
+                  @click="actionClicked('fontUp')"
+                />
+                <LxButton
+                  kind="ghost"
+                  variant="icon-only"
+                  icon="zoom-out"
+                  :label="$t('pages.akordiSongView.fontDown.label')"
+                  @click="actionClicked('fontDown')"
+                />
+                <div class="lx-divider"></div>
 
-              <label class="lx-data toolbar-label">{{
-                $t('pages.akordiSongView.autoScroll.label', {
-                  speed: autoScrollerSpeedFormatted,
-                })
-              }}</label>
-              <LxButton
-                kind="ghost"
-                variant="icon-only"
-                :icon="pauseAutoScroll ? 'pause' : autoScrollerIcon"
-                :active="autoScrollerSpeed > 0"
-                :label="$t('pages.akordiSongView.autoScroll.playDescription')"
-                @click="autoScrollerUp"
-              />
-              <LxButton
-                kind="ghost"
-                variant="icon-only"
-                icon="stop"
-                :label="$t('pages.akordiSongView.autoScroll.stopDescription')"
-                @click="autoScrollerSpeed = 0"
-              />
+                <label class="lx-data toolbar-label">{{
+                  $t('pages.akordiSongView.autoScroll.label', {
+                    speed: autoScrollerSpeedFormatted,
+                  })
+                }}</label>
+                <LxButton
+                  kind="ghost"
+                  variant="icon-only"
+                  :icon="pauseAutoScroll ? 'pause' : autoScrollerIcon"
+                  :active="autoScrollerSpeed > 0"
+                  :label="$t('pages.akordiSongView.autoScroll.playDescription')"
+                  @click="autoScrollerUp"
+                />
+                <LxButton
+                  kind="ghost"
+                  variant="icon-only"
+                  icon="stop"
+                  :label="$t('pages.akordiSongView.autoScroll.stopDescription')"
+                  @click="autoScrollerSpeed = 0"
+                />
+              </template>
             </template>
           </LxToolbar>
         </LxToolbarGroup>
@@ -686,7 +723,10 @@ onUnmounted(() => {
           <p class="lx-data">{{ lxDateUtils.formatDateTime(item.updatedDate) }}</p>
         </LxRow>
       </template>
-      <LxSection v-show="hasAbc && settingsStore.showAbc" id="bodyAbc">
+      <LxSection v-if="playAlong" id="playAlong">
+        <ChordPlayer :video-url="videoUrl" :segments="segments" :duration="duration" />
+      </LxSection>
+      <LxSection v-show="!playAlong && hasAbc && settingsStore.showAbc" id="bodyAbc">
         <AbcViewer
           :abc="item.bodyAbc"
           @audio-unsupported="
@@ -694,7 +734,7 @@ onUnmounted(() => {
           "
         />
       </LxSection>
-      <LxSection v-show="hasChords && settingsStore.showChords" id="chords">
+      <LxSection v-show="!playAlong && hasChords && settingsStore.showChords" id="chords">
         <div style="display: flex; flex-wrap: wrap; align-items: flex-start">
           <ChordSvg
             :chord="chord"
@@ -704,7 +744,7 @@ onUnmounted(() => {
           ></ChordSvg>
         </div>
       </LxSection>
-      <LxSection id="body">
+      <LxSection v-show="!playAlong" id="body">
         <p class="pre" v-html="item.bodyWithMarkup" :style="{ fontSize: fontSize + 'em' }"></p>
       </LxSection>
     </LxForm>

--- a/src/views/SongView.vue
+++ b/src/views/SongView.vue
@@ -592,6 +592,23 @@ onUnmounted(() => {
 .song-reference {
   margin-top: 1rem;
 }
+
+/* Play-along entry CTA — sits at the top of the song content. */
+.play-along-cta {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+.play-along-cta-hint {
+  margin: 0;
+}
+/* Exit button above the player. */
+.play-along-exit {
+  display: flex;
+  justify-content: flex-end;
+  margin-bottom: 0.75rem;
+}
 </style>
 <template>
   <LxLoaderView :loading="loading">
@@ -602,7 +619,7 @@ onUnmounted(() => {
       :show-post-header-info="true"
       :show-pre-header-info="true"
       kind="compact"
-      :show-footer="true"
+      :show-footer="!playAlong"
       :sticky-header="false"
       :sticky-footer="true"
     >
@@ -610,80 +627,65 @@ onUnmounted(() => {
         <LxToolbarGroup id="songToolbarGroup">
           <LxToolbar :noBorders="true">
             <template #leftArea>
-              <template v-if="playable">
-                <!-- Labeled (not icon-only) so this flagship action is not
-                     confused with the icon-only auto-scroll play button, which
-                     shares the 'play' glyph at rest. -->
-                <LxButton
-                  :kind="playAlong ? 'ghost' : 'primary'"
-                  :icon="playAlong ? 'close' : 'play'"
-                  :active="playAlong"
-                  :label="playAlong ? $t('pages.playAlong.exit') : $t('pages.playAlong.toggle')"
-                  @click="togglePlayAlong"
-                />
-                <div class="lx-divider"></div>
-              </template>
-              <template v-if="!playAlong">
-                <label class="lx-data toolbar-label">{{
-                  $t('pages.akordiSongView.transposeHeader', {
-                    offset: offsetFormatted,
-                  })
-                }}</label>
-                <LxButton
-                  kind="ghost"
-                  variant="icon-only"
-                  icon="move-up"
-                  :label="$t('pages.akordiSongView.transposeUp.label')"
-                  @click="actionClicked('transposeUp')"
-                />
-                <LxButton
-                  kind="ghost"
-                  variant="icon-only"
-                  icon="move-down"
-                  :label="$t('pages.akordiSongView.transposeDown.label')"
-                  @click="actionClicked('transposeDown')"
-                />
-                <div class="lx-divider"></div>
-                <label class="lx-data toolbar-label">{{
-                  $t('pages.akordiSongView.fontUp.label')
-                }}</label>
-                <LxButton
-                  kind="ghost"
-                  variant="icon-only"
-                  icon="zoom-in"
-                  :label="$t('pages.akordiSongView.fontUp.label')"
-                  @click="actionClicked('fontUp')"
-                />
-                <LxButton
-                  kind="ghost"
-                  variant="icon-only"
-                  icon="zoom-out"
-                  :label="$t('pages.akordiSongView.fontDown.label')"
-                  @click="actionClicked('fontDown')"
-                />
-                <div class="lx-divider"></div>
+              <label class="lx-data toolbar-label">{{
+                $t('pages.akordiSongView.transposeHeader', {
+                  offset: offsetFormatted,
+                })
+              }}</label>
+              <LxButton
+                kind="ghost"
+                variant="icon-only"
+                icon="move-up"
+                :label="$t('pages.akordiSongView.transposeUp.label')"
+                @click="actionClicked('transposeUp')"
+              />
+              <LxButton
+                kind="ghost"
+                variant="icon-only"
+                icon="move-down"
+                :label="$t('pages.akordiSongView.transposeDown.label')"
+                @click="actionClicked('transposeDown')"
+              />
+              <div class="lx-divider"></div>
+              <label class="lx-data toolbar-label">{{
+                $t('pages.akordiSongView.fontUp.label')
+              }}</label>
+              <LxButton
+                kind="ghost"
+                variant="icon-only"
+                icon="zoom-in"
+                :label="$t('pages.akordiSongView.fontUp.label')"
+                @click="actionClicked('fontUp')"
+              />
+              <LxButton
+                kind="ghost"
+                variant="icon-only"
+                icon="zoom-out"
+                :label="$t('pages.akordiSongView.fontDown.label')"
+                @click="actionClicked('fontDown')"
+              />
+              <div class="lx-divider"></div>
 
-                <label class="lx-data toolbar-label">{{
-                  $t('pages.akordiSongView.autoScroll.label', {
-                    speed: autoScrollerSpeedFormatted,
-                  })
-                }}</label>
-                <LxButton
-                  kind="ghost"
-                  variant="icon-only"
-                  :icon="pauseAutoScroll ? 'pause' : autoScrollerIcon"
-                  :active="autoScrollerSpeed > 0"
-                  :label="$t('pages.akordiSongView.autoScroll.playDescription')"
-                  @click="autoScrollerUp"
-                />
-                <LxButton
-                  kind="ghost"
-                  variant="icon-only"
-                  icon="stop"
-                  :label="$t('pages.akordiSongView.autoScroll.stopDescription')"
-                  @click="autoScrollerSpeed = 0"
-                />
-              </template>
+              <label class="lx-data toolbar-label">{{
+                $t('pages.akordiSongView.autoScroll.label', {
+                  speed: autoScrollerSpeedFormatted,
+                })
+              }}</label>
+              <LxButton
+                kind="ghost"
+                variant="icon-only"
+                :icon="pauseAutoScroll ? 'pause' : autoScrollerIcon"
+                :active="autoScrollerSpeed > 0"
+                :label="$t('pages.akordiSongView.autoScroll.playDescription')"
+                @click="autoScrollerUp"
+              />
+              <LxButton
+                kind="ghost"
+                variant="icon-only"
+                icon="stop"
+                :label="$t('pages.akordiSongView.autoScroll.stopDescription')"
+                @click="autoScrollerSpeed = 0"
+              />
             </template>
           </LxToolbar>
         </LxToolbarGroup>
@@ -725,7 +727,29 @@ onUnmounted(() => {
           <p class="lx-data">{{ lxDateUtils.formatDateTime(item.updatedDate) }}</p>
         </LxRow>
       </template>
+      <!-- Play-along entry — a prominent CTA at the top of the song content,
+           kept out of the crowded footer toolbar. Shown only for playable
+           songs when not already in play-along. -->
+      <LxSection v-if="playable && !playAlong" id="playAlongEnter">
+        <div class="play-along-cta">
+          <LxButton
+            kind="primary"
+            icon="play"
+            :label="$t('pages.playAlong.toggle')"
+            @click="togglePlayAlong"
+          />
+          <p class="lx-description play-along-cta-hint">{{ $t('pages.playAlong.hint') }}</p>
+        </div>
+      </LxSection>
       <LxSection v-if="playAlong" id="playAlong">
+        <div class="play-along-exit">
+          <LxButton
+            kind="ghost"
+            icon="close"
+            :label="$t('pages.playAlong.exit')"
+            @click="togglePlayAlong"
+          />
+        </div>
         <ChordPlayer :video-url="videoUrl" :segments="segments" :duration="duration" />
       </LxSection>
       <LxSection v-show="!playAlong && hasAbc && settingsStore.showAbc" id="bodyAbc">

--- a/tests/unit/chordSync.test.js
+++ b/tests/unit/chordSync.test.js
@@ -1,0 +1,161 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  activeSegmentIndex,
+  nextSegment,
+  segmentProgress,
+  segmentWindow,
+  youtubeId,
+} from '@/utils/chordSync';
+
+describe('youtubeId', () => {
+  it.each([
+    ['https://www.youtube.com/watch?v=V4e_38Z9xDA', 'V4e_38Z9xDA'],
+    ['https://youtu.be/V4e_38Z9xDA', 'V4e_38Z9xDA'],
+    ['https://www.youtube.com/embed/V4e_38Z9xDA', 'V4e_38Z9xDA'],
+    ['https://www.youtube.com/shorts/V4e_38Z9xDA', 'V4e_38Z9xDA'],
+    ['https://www.youtube.com/watch?v=V4e_38Z9xDA&list=abc', 'V4e_38Z9xDA'],
+  ])('extracts the id from %s', (url, id) => {
+    expect(youtubeId(url)).toBe(id);
+  });
+
+  it('returns empty string when no id is present', () => {
+    expect(youtubeId('')).toBe('');
+    expect(youtubeId('https://example.com/watch')).toBe('');
+    expect(youtubeId(null)).toBe('');
+  });
+});
+
+describe('activeSegmentIndex', () => {
+  const segments = [
+    { start: 0, end: 2.5, label: 'C' },
+    { start: 2.5, end: 5, label: 'G' },
+    { start: 5, end: 7.5, label: 'Am' },
+  ];
+
+  it('returns -1 before the first segment starts', () => {
+    expect(activeSegmentIndex(segments, -1)).toBe(-1);
+  });
+
+  it('matches a segment on its start (inclusive) and within its span', () => {
+    expect(activeSegmentIndex(segments, 0)).toBe(0);
+    expect(activeSegmentIndex(segments, 2.4)).toBe(0);
+  });
+
+  it('is end-exclusive: the boundary belongs to the next segment', () => {
+    expect(activeSegmentIndex(segments, 2.5)).toBe(1);
+    expect(activeSegmentIndex(segments, 5)).toBe(2);
+  });
+
+  it('keeps the last chord highlighted past the end', () => {
+    expect(activeSegmentIndex(segments, 100)).toBe(2);
+  });
+
+  it('handles empty / non-array input', () => {
+    expect(activeSegmentIndex([], 3)).toBe(-1);
+    expect(activeSegmentIndex(undefined, 3)).toBe(-1);
+  });
+});
+
+describe('nextSegment', () => {
+  const segments = [
+    { start: 0, end: 2.5, label: 'C' },
+    { start: 2.5, end: 5, label: 'G' },
+    { start: 5, end: 7.5, label: 'Am' },
+  ];
+
+  it('returns the following segment for a middle index', () => {
+    expect(nextSegment(segments, 0)).toEqual({ start: 2.5, end: 5, label: 'G' });
+    expect(nextSegment(segments, 1)).toEqual({ start: 5, end: 7.5, label: 'Am' });
+  });
+
+  it('returns null on the last segment', () => {
+    expect(nextSegment(segments, 2)).toBeNull();
+  });
+
+  it('returns null when nothing is active or input is empty', () => {
+    expect(nextSegment(segments, -1)).toBeNull();
+    expect(nextSegment([], 0)).toBeNull();
+    expect(nextSegment(undefined, 0)).toBeNull();
+  });
+});
+
+describe('segmentProgress', () => {
+  const segments = [{ start: 4, end: 8, label: 'C' }]; // 4s span
+
+  it('is 0 at the start', () => {
+    expect(segmentProgress(segments, 0, 4)).toBe(0);
+  });
+
+  it('is ~0.5 at the midpoint', () => {
+    expect(segmentProgress(segments, 0, 6)).toBeCloseTo(0.5, 5);
+  });
+
+  it('is 1 at the end', () => {
+    expect(segmentProgress(segments, 0, 8)).toBe(1);
+  });
+
+  it('clamps before the start and after the end', () => {
+    expect(segmentProgress(segments, 0, 0)).toBe(0);
+    expect(segmentProgress(segments, 0, 100)).toBe(1);
+  });
+
+  it('returns 0 for an invalid index', () => {
+    expect(segmentProgress(segments, -1, 6)).toBe(0);
+    expect(segmentProgress(segments, 5, 6)).toBe(0);
+    expect(segmentProgress([], 0, 6)).toBe(0);
+  });
+
+  it('does not divide by zero for a zero-length segment', () => {
+    const zero = [{ start: 3, end: 3, label: 'C' }];
+    expect(segmentProgress(zero, 0, 2)).toBe(0);
+    expect(segmentProgress(zero, 0, 3)).toBe(1);
+  });
+});
+
+describe('segmentWindow', () => {
+  const segments = Array.from({ length: 10 }, (_, i) => ({
+    start: i,
+    end: i + 1,
+    label: `c${i}`,
+  }));
+
+  it('centres a window around the active index', () => {
+    const win = segmentWindow(segments, 4, { before: 1, after: 2 });
+    expect(win.items.map((it) => it.index)).toEqual([3, 4, 5, 6]);
+    expect(win.start).toBe(3);
+    expect(win.end).toBe(7);
+  });
+
+  it('clamps at the song start', () => {
+    const win = segmentWindow(segments, 0, { before: 3, after: 2 });
+    expect(win.items.map((it) => it.index)).toEqual([0, 1, 2]);
+    expect(win.start).toBe(0);
+    expect(win.end).toBe(3);
+  });
+
+  it('clamps at the song end', () => {
+    const win = segmentWindow(segments, 9, { before: 2, after: 3 });
+    expect(win.items.map((it) => it.index)).toEqual([7, 8, 9]);
+    expect(win.start).toBe(7);
+    expect(win.end).toBe(10);
+  });
+
+  it('anchors at the start when nothing is active yet', () => {
+    const win = segmentWindow(segments, -1, { before: 1, after: 2 });
+    expect(win.items.map((it) => it.index)).toEqual([0, 1, 2]);
+  });
+
+  it('returns the whole list when it is smaller than the window', () => {
+    const few = segments.slice(0, 2);
+    const win = segmentWindow(few, 0, { before: 1, after: 5 });
+    expect(win.items.map((it) => it.index)).toEqual([0, 1]);
+    expect(win.start).toBe(0);
+    expect(win.end).toBe(2);
+  });
+
+  it('handles empty input', () => {
+    expect(segmentWindow([], 0)).toEqual({ items: [], start: 0, end: 0 });
+    expect(segmentWindow(undefined, 0)).toEqual({ items: [], start: 0, end: 0 });
+  });
+});


### PR DESCRIPTION
## What

Surfaces the admin portal's YouTube chord-sync player to end users on the public song page, as a **mode toggle** (not a new permanent section).

When a song has both a `youtubeLink` and a non-empty `chordTimeline`, a **"Spēlēt līdzi"** toggle appears in the song toolbar. Activating it reshapes the page into a lean-back player: embedded video, a current/next chord HUD, and a scrolling chord track synced to playback. The read view (lyrics/ABC/chords) is the default and is restored on exit. **Same route, no SEO change.**

## Why this shape

- **Works for the whole catalog.** The toggle only shows for playable songs, so lyric-less and un-synced songs are unaffected — play-along never depends on lyrics.
- **No new engine in SongView.** `ChordPlayer.vue` (already unit-tested in admin-portal) is ported as a self-contained component; SongView grows by a computed, a ref, a toolbar button, and one conditional block.
- **Frontend-only.** `GET /api/v2/songs/{id}` already returns `youtubeLink` + `chordTimeline`; no backend change.

## Changes

- **Port** `ChordPlayer.vue` + `chordSync.js` (framework-free, 26 unit tests) from admin-portal; i18n keys retargeted to `pages.playAlong.*`
- **SongView**: derive `videoUrl`/`segments`/`duration`/`playable`; mode toggle; stop auto-scroller on entry; reset on song change; hide read controls in play-along
- **i18n**: `playAlong` strings for lv/lt/ee/es

## Verification

- Unit suite **33/33** pass (`vitest`), `vite build` ✓, eslint clean
- **E2E** (`akordi/tests#<PR>`): playable flow + two negative cases — **executed green against a live dev server**. Keyboard seek + `aria-live` asserted.
- **Visually verified** live: in-theme HUD (brand now-chord + depleting bar), next-chord card, proportional chord track, real video embed.

## Notes

- One design call: play-along mode **fully hides** the read view for a clean switch. Easy to change to keep lyrics visible below the player if preferred.
- Fixed two issues the live run caught: LxForm prefixes section ids (`#song-view-form-body`), and the cookie banner overlaps the footer toolbar (handled in the e2e).

🤖 Generated with [Claude Code](https://claude.com/claude-code)