### PR TITLE
feat: chord diagrams in play-along + left-aligned back button

### DIFF
--- a/src/components/ChordPlayer.vue
+++ b/src/components/ChordPlayer.vue
@@ -173,10 +173,23 @@ async function build() {
   }
   player = new YT.Player(mount.value, {
     videoId: videoId.value,
+    // The API otherwise injects a fixed width="640" height="390" iframe. It is
+    // created outside Vue, so scoped CSS never reaches it — size it here so it
+    // stays fluid and never overflows narrow (mobile) layouts.
+    width: '100%',
+    height: '100%',
     playerVars: { rel: 0, modestbranding: 1, playsinline: 1 },
     events: {
       onReady: () => {
         ready.value = true;
+        // Belt and braces: the width/height options above set the iframe
+        // attributes, but pin the inline style too so a 640px attribute can
+        // never win over the responsive box.
+        const frame = player && typeof player.getIframe === 'function' && player.getIframe();
+        if (frame) {
+          frame.style.width = '100%';
+          frame.style.height = '100%';
+        }
       },
       onStateChange: (event) => {
         // 1 = playing → track time; anything else → stop the ticker.

--- a/src/views/SongView.vue
+++ b/src/views/SongView.vue
@@ -609,6 +609,12 @@ onUnmounted(() => {
   justify-content: flex-start;
   margin-bottom: 0.75rem;
 }
+/* The play-along section is a CSS-grid item (LxForm), which defaults to
+   min-width:auto and would refuse to shrink below a wide child (the video).
+   Allow it to shrink to the grid track so nothing overflows on mobile. */
+#song-view-form-playAlong {
+  min-width: 0;
+}
 /* Chord diagrams below the player in play-along mode. */
 .play-along-chords {
   display: flex;

--- a/src/views/SongView.vue
+++ b/src/views/SongView.vue
@@ -603,11 +603,18 @@ onUnmounted(() => {
 .play-along-cta-hint {
   margin: 0;
 }
-/* Exit button above the player. */
+/* Exit button above the player, left-aligned like a back control. */
 .play-along-exit {
   display: flex;
-  justify-content: flex-end;
+  justify-content: flex-start;
   margin-bottom: 0.75rem;
+}
+/* Chord diagrams below the player in play-along mode. */
+.play-along-chords {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-start;
+  margin-top: 1rem;
 }
 </style>
 <template>
@@ -745,12 +752,22 @@ onUnmounted(() => {
         <div class="play-along-exit">
           <LxButton
             kind="ghost"
-            icon="close"
+            icon="undo"
             :label="$t('pages.playAlong.exit')"
             @click="togglePlayAlong"
           />
         </div>
         <ChordPlayer :video-url="videoUrl" :segments="segments" :duration="duration" />
+        <!-- Chord fingering diagrams, same as the read view, so the player can
+             see how to play the chord the HUD is calling. -->
+        <div v-if="hasChords" class="play-along-chords">
+          <ChordSvg
+            :chord="chord"
+            :instrument="settingsStore.instrument"
+            v-for="chord in chords"
+            :key="chord"
+          ></ChordSvg>
+        </div>
       </LxSection>
       <LxSection v-show="!playAlong && hasAbc && settingsStore.showAbc" id="bodyAbc">
         <AbcViewer


### PR DESCRIPTION
Follow-up to #39 based on review feedback.

## Changes

- **Chord diagrams in play-along.** The chord fingering charts (the same `ChordSvg` set shown in the read view) now render below the player in play-along mode, so someone playing along can see *how* to finger the chord the HUD is calling — not just its name.
- **Back button moved left.** The "Atpakaļ uz tekstu" (back to lyrics) control was right-aligned; it's now left-aligned with an `undo`/back-arrow icon, reading as a proper back control.

## Verification

- Screenshotted live: A/D/E diagrams appear under the chord track; back button sits top-left with a clean back-arrow glyph (switched off `chevron-left`, which rendered as a fallback box, to the confirmed-valid `undo`).
- `vite build` ✓, eslint clean, play-along e2e 3/3 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)