### PR TITLE
fix: iOS horizontal scroll from off-canvas nav rail

### DIFF
--- a/src/assets/styles.css
+++ b/src/assets/styles.css
@@ -1,3 +1,13 @@
+/* iOS horizontal-scroll fix. The shell's collapsed nav rail (.lx-nav-panel) is
+   position:fixed and parked off the right edge (left:100vw, 48px wide). body
+   already has overflow-x:hidden, but iOS Safari scrolls the <html> element, and
+   the shell leaves that overflow-x:visible — so the off-canvas rail becomes
+   pannable. Clip the root's horizontal overflow (clip, not hidden, so overflow-y
+   stays visible and the sticky toolbar/footer keep working). */
+html {
+  overflow-x: clip;
+}
+
 .lx-main-button .lx-logo img {
   height: 42px;
   display: none;


### PR DESCRIPTION
## Symptom

On mobile (reported on iOS Safari) every page — including plain read mode — could be scrolled/panned sideways.

## Root cause

Measured on the deployed test site: the document itself does **not** overflow in Chromium (`scrollWidth == viewport` on every route). The only element past the right edge is the shell's collapsed nav rail `.lx-nav-panel`:

- `position: fixed; left: 100vw` (parked 48px off the right edge in its hidden state).

Because it's `position: fixed`, `body { overflow-x: hidden }` can't contain it. iOS Safari scrolls the **`<html>`** element, and the shell leaves `html` at `overflow-x: visible` — so the off-canvas rail becomes pannable. Chromium can't reproduce it (it doesn't let you scroll to off-viewport fixed elements), which is why it never showed in screenshots.

This is **app-wide and pre-existing** — present on home/search too, unrelated to play-along.

## Fix

`html { overflow-x: clip; }` in the portal's global stylesheet.

- `clip` (not `hidden`) so `overflow-y` stays `visible` and the sticky toolbar/footer keep working — verified in Chromium: `htmlOX: clip`, `htmlOY: visible`, footer still `position: sticky`, no horizontal scroll.
- Matches the intent of the existing `body { overflow-x: hidden }`; adds no new clipping beyond what body already did.

## Verification note

The symptom is iOS-Safari-specific and **cannot be reproduced in headless Chromium** (no horizontal scroll there to begin with). This is the standard, documented fix for a fixed off-canvas element + body-only overflow-hidden. Needs a final check on a real iOS device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)