### PR TITLE
fix: hide off-canvas nav panel on mobile (real iOS scroll fix)

### DIFF
--- a/src/assets/styles.css
+++ b/src/assets/styles.css
@@ -8,6 +8,19 @@ html {
   overflow-x: clip;
 }
 
+/* ...but the real culprit is position:fixed, so overflow can't contain it: on
+   mobile the collapsed (closed) public nav panel is parked off-canvas at
+   left:100vw as a 48px rail, and iOS Safari lets you pan sideways to it on
+   every page. It only holds the menu when OPEN (left:0, .lx-collapsed removed),
+   so hide it while closed. Scoped to <=900px and matching the shell's own
+   selector plus .lx-collapsed so it (a) only hides on mobile, not the desktop
+   collapsed sidebar, and (b) out-specifies the shell's display:flex rule. */
+@media (max-width: 900px) {
+  .lx .lx-layout.lx-layout-public.lx-collapsed .lx-nav-panel {
+    display: none;
+  }
+}
+
 .lx-main-button .lx-logo img {
   height: 42px;
   display: none;


### PR DESCRIPTION
Follow-up to #41 — that `html { overflow-x: clip }` did **not** fix the iOS horizontal scroll, because the culprit is `position: fixed` and overflow can't contain a fixed element.

## Real cause (measured)
On mobile the collapsed **public** nav panel `.lx-nav-panel` is parked off-canvas at `left: 100vw` as a 48px rail. It's `position: fixed`, so `body`/`html` overflow can't clip it, and iOS Safari lets you pan sideways to it on every page. It only holds the menu when **open** (`left: 0`, `.lx-collapsed` removed).

## Fix
Hide the panel while collapsed, mobile only:
```css
@media (max-width: 900px) {
  .lx .lx-layout.lx-layout-public.lx-collapsed .lx-nav-panel { display: none; }
}
```
Scoped + specific so it (a) only hides on mobile, not the desktop collapsed sidebar, and (b) out-specifies the shell's `display: flex` rule.

## Verified (Chromium, 390px)
- Closed → `display: none`, panel out of layout, no off-canvas element.
- Open (tap hamburger) → `display: flex`, `left: 0`, nav links clickable.
- Desktop (1400px) → panel `display: grid`, unaffected.

Still worth a final check on a real iOS device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)