### PR TITLE
revert: remove redundant iOS scroll fixes (#41, #42)

### DIFF
--- a/src/assets/styles.css
+++ b/src/assets/styles.css
@@ -1,26 +1,3 @@
-/* iOS horizontal-scroll fix. The shell's collapsed nav rail (.lx-nav-panel) is
-   position:fixed and parked off the right edge (left:100vw, 48px wide). body
-   already has overflow-x:hidden, but iOS Safari scrolls the <html> element, and
-   the shell leaves that overflow-x:visible — so the off-canvas rail becomes
-   pannable. Clip the root's horizontal overflow (clip, not hidden, so overflow-y
-   stays visible and the sticky toolbar/footer keep working). */
-html {
-  overflow-x: clip;
-}
-
-/* ...but the real culprit is position:fixed, so overflow can't contain it: on
-   mobile the collapsed (closed) public nav panel is parked off-canvas at
-   left:100vw as a 48px rail, and iOS Safari lets you pan sideways to it on
-   every page. It only holds the menu when OPEN (left:0, .lx-collapsed removed),
-   so hide it while closed. Scoped to <=900px and matching the shell's own
-   selector plus .lx-collapsed so it (a) only hides on mobile, not the desktop
-   collapsed sidebar, and (b) out-specifies the shell's display:flex rule. */
-@media (max-width: 900px) {
-  .lx .lx-layout.lx-layout-public.lx-collapsed .lx-nav-panel {
-    display: none;
-  }
-}
-
 .lx-main-button .lx-logo img {
   height: 42px;
   display: none;


### PR DESCRIPTION
Reverts the two iOS horizontal-scroll fixes — they were fixing a non-problem.

## Evidence (real device)
Tested on a physical iPhone (iOS 26.5.1) via `ios-webkit-debug-proxy`, running JS in the actual Safari page:
- A `position:fixed` element parked 48px off-canvas (`left:100vw`) → **`maxScrollLeft = 0`**. It does **not** create horizontal scroll on iOS.
- Same with the nav panel forced visible, and with an extra raw fixed off-canvas div: `maxScrollLeft = 0` in every case.
- The reported "scroll" turned out to be a **Chrome-on-iOS zoom artifact**, not a layout issue.

## Removed
- `html { overflow-x: clip }` (#41)
- `.lx-collapsed .lx-nav-panel { display: none }` mobile override (#42)

`styles.css` is byte-for-byte back to its prior state (verified: empty diff vs the commit before #41).

🤖 Generated with [Claude Code](https://claude.com/claude-code)