### PR TITLE
fix: bind LxShell v-model:navBarSwitch so the menu opens on lx-ui 2.2.9

### DIFF
--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -32,6 +32,9 @@ const secondsCheckApiInterval = 30;
 const { idle } = useIdle(secondsToIdle * 1000);
 
 const idleModalOpened = ref(false);
+// lx-ui 2.2.9 exposes the nav-bar collapsed/expanded state as a controlled
+// v-model; without binding it the menu toggle button does nothing.
+const navBarSwitch = ref(null);
 const translate = useI18n();
 const $t = translate.t;
 const route = useRoute();
@@ -377,6 +380,7 @@ function idleModalSecondary() {
         :confirmPrimaryButtonBusy="false"
         :confirmPrimaryButtonDestructive="true"
         v-model:notifications="notify.notifications"
+        v-model:navBarSwitch="navBarSwitch"
         @confirmModalClose="confirmModalClosed"
         @go-home="goHome"
         @go-back="goBack"


### PR DESCRIPTION
## Problem

After the latest release, the navigation menu could not be opened.

## Root cause

lx-ui 2.2.9 changed the shell nav-toggle contract: the collapsed/expanded state is now a **controlled `navBarSwitch` v-model** that the host app must bind (the lx-ui reference shell does this). `MainLayout.vue` never bound it, so clicking the menu button no longer removed the `lx-collapsed` class — the nav panel never slid in and the menu appeared stuck closed.

## Fix

Bind `v-model:navBarSwitch` on `LxShell` to a local `ref(null)`. Stays on the released lx-ui 2.2.9 — the only change is the 4-line binding.

## Verification

Reproduced against LxShell 2.2.9 in a headless browser (public mode): before the fix, clicking `#nav-toggle` did nothing; after, the nav panel moves from x=390 to x=0 and `lx-collapsed` is dropped. Production build passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013ijgXRm3KwrG2LegGHQFCP)_