### PR TITLE
test: cover search_no_results settle-timer behavior + run tests in CI

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -35,6 +35,8 @@ jobs:
         run: bun install --frozen-lockfile
       - name: Lint
         run: bun run lint
+      - name: Test
+        run: bun run test
       - name: Build
         run: bun run build
       # Install the cosign tool except on PR

--- a/src/views/SongSearch.vue
+++ b/src/views/SongSearch.vue
@@ -1,7 +1,7 @@
 <script setup>
 import akordiService from '@/services/akordiService';
 import { LxContentSwitcher, LxList, LxLoader } from '@dativa-lv/lx-ui';
-import { onMounted, ref, watch } from 'vue';
+import { onMounted, onUnmounted, ref, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { listTexts } from '@/utils/texts';
 
@@ -24,6 +24,20 @@ const pageSize = 10;
 const searchString = ref('');
 const totalCount = ref(0);
 
+// Only report search_no_results once the user has settled on a query. LxList
+// debounces keystrokes into search calls, but a brief pause mid-typing still
+// completes a search, so partial terms (e.g. "Cir", "Circ", "Circen") were all
+// logged as no-result searches. Defer the event and cancel it if another search
+// starts first, so only the query the user actually stopped on is reported.
+const NO_RESULTS_EVENT_DELAY = 2000;
+let noResultsTimer = null;
+function cancelNoResultsEvent() {
+  if (noResultsTimer) {
+    clearTimeout(noResultsTimer);
+    noResultsTimer = null;
+  }
+}
+
 function titleOrHighlight(song) {
   return song['@search.highlights'].title?.length
     ? song['@search.highlights'].title[0]
@@ -40,6 +54,9 @@ async function search(q, more = false) {
   searchString.value = q;
   if (!more) {
     totalCount.value = 0;
+    // A fresh query means the user kept typing/searching, so drop any
+    // no-results event still pending from the previous term.
+    cancelNoResultsEvent();
   }
   if (!q) {
     items.value = [];
@@ -59,7 +76,13 @@ async function search(q, more = false) {
     }
     // One event per completed server search (LxList debounces input). !more = a fresh query, not paging.
     if (resp.data.value.length === 0) {
-      if (!more) event('search_no_results', { search_term: q });
+      if (!more) {
+        // Defer so a term the user is still typing past doesn't get logged.
+        noResultsTimer = setTimeout(() => {
+          event('search_no_results', { search_term: q });
+          noResultsTimer = null;
+        }, NO_RESULTS_EVENT_DELAY);
+      }
       return;
     }
     if (!more) event('search', { search_term: q });
@@ -128,6 +151,10 @@ onMounted(async () => {
     search(route.query.q);
   }
   viewStore.goBack = true;
+});
+onUnmounted(() => {
+  // Don't fire for a query the user abandoned by navigating away.
+  cancelNoResultsEvent();
 });
 </script>
 <style>

--- a/tests/unit/songSearch.test.js
+++ b/tests/unit/songSearch.test.js
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mount, flushPromises } from '@vue/test-utils';
+
+const { search, gtagEvent, push } = vi.hoisted(() => ({
+  search: vi.fn(),
+  gtagEvent: vi.fn(),
+  push: vi.fn(),
+}));
+
+vi.mock('@dativa-lv/lx-ui', () => ({
+  LxList: {
+    name: 'LxList',
+    props: ['items', 'searchString', 'showLoadMore'],
+    emits: ['action-click', 'update:items', 'update:search-string', 'load-more'],
+    template: '<div />',
+  },
+  LxContentSwitcher: { name: 'LxContentSwitcher', props: ['modelValue'], template: '<div />' },
+  LxLoader: { name: 'LxLoader', props: ['loading'], template: '<div />' },
+}));
+vi.mock('@/services/akordiService', () => ({ default: { search } }));
+vi.mock('vue-gtag', () => ({ event: gtagEvent }));
+vi.mock('vue-i18n', () => ({ useI18n: () => ({ t: (key) => key }) }));
+vi.mock('vue-router', () => ({
+  useRoute: () => ({ query: {} }),
+  useRouter: () => ({ push }),
+}));
+vi.mock('@/stores/useViewStore', () => ({ default: () => ({ goBack: false }) }));
+vi.mock('@/stores/useNotifyStore', () => ({ default: () => ({ pushError: vi.fn() }) }));
+vi.mock('@/utils/texts', () => ({ listTexts: () => ({}) }));
+
+import SongSearch from '@/views/SongSearch.vue';
+
+const noResults = () => ({ data: { value: [], '@odata.count': 0 } });
+const withResults = () => ({
+  data: {
+    value: [{ id: 1, title: 'A song', mainArtistTitle: 'A band', '@search.highlights': {} }],
+    '@odata.count': 1,
+  },
+});
+
+const list = (wrapper) => wrapper.findComponent({ name: 'LxList' });
+// Simulate a user (debounced) keystroke arriving at the view.
+const type = async (wrapper, term) => {
+  list(wrapper).vm.$emit('update:search-string', term);
+  await flushPromises();
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.useFakeTimers();
+});
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('SongSearch — search_no_results reporting', () => {
+  it('reports only the term the user settles on, not the prefixes typed through', async () => {
+    search.mockResolvedValue(noResults());
+    const wrapper = mount(SongSearch);
+
+    // User types a single word; each debounced keystroke completes a search.
+    await type(wrapper, 'Cir');
+    await type(wrapper, 'Circ');
+    await type(wrapper, 'Circen');
+    await type(wrapper, 'Circenī');
+
+    // Still typing — nothing reported yet.
+    expect(gtagEvent).not.toHaveBeenCalled();
+
+    // User stops; the settle window elapses.
+    await vi.advanceTimersByTimeAsync(2000);
+
+    const noResultsCalls = gtagEvent.mock.calls.filter((c) => c[0] === 'search_no_results');
+    expect(noResultsCalls).toHaveLength(1);
+    expect(noResultsCalls[0][1]).toEqual({ search_term: 'Circenī' });
+  });
+
+  it('does not report when a later keystroke finds results', async () => {
+    search.mockResolvedValueOnce(noResults()); // "Circ*" fallback also empty
+    search.mockResolvedValueOnce(noResults());
+    search.mockResolvedValue(withResults()); // "Circle" hits
+    const wrapper = mount(SongSearch);
+
+    await type(wrapper, 'Circ'); // no results -> event pending
+    await type(wrapper, 'Circle'); // results -> cancels the pending no-results event
+    await vi.advanceTimersByTimeAsync(2000);
+
+    expect(gtagEvent.mock.calls.filter((c) => c[0] === 'search_no_results')).toHaveLength(0);
+    expect(gtagEvent.mock.calls.filter((c) => c[0] === 'search')).toHaveLength(1);
+  });
+
+  it('does not report a term abandoned by navigating away (unmount)', async () => {
+    search.mockResolvedValue(noResults());
+    const wrapper = mount(SongSearch);
+
+    await type(wrapper, 'Circenī'); // no results -> event pending
+    wrapper.unmount();
+    await vi.advanceTimersByTimeAsync(2000);
+
+    expect(gtagEvent.mock.calls.filter((c) => c[0] === 'search_no_results')).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Context

Follow-up to #46, which fixed `search_no_results` firing for every intermediate prefix a user typed through. This adds unit-test coverage for that behavior and wires the test suite into CI.

## Tests (`tests/unit/songSearch.test.js`)

Uses the repo's existing `@vue/test-utils` + module-mock pattern, with Vitest fake timers to exercise the settle window:

1. **Reports only the settled term** — emits `Cir` → `Circ` → `Circen` → `Circenī` (all zero-result). Asserts nothing is reported while typing, and after the settle window exactly one `search_no_results` fires, for `Circenī` only.
2. **A later keystroke that finds results cancels the pending event** — `Circ` (empty) then `Circle` (hits). Asserts no `search_no_results` and a single `search` event.
3. **A term abandoned by navigating away is not reported** — types a no-result term, unmounts before the window elapses, asserts nothing is reported.

## CI (`.github/workflows/docker.yml`)

The `build` job previously linted and built but never ran the Vitest suite, so unit tests didn't gate merges. Added a `Test` step (`bun run test`) between `Lint` and `Build`. Confirmed green on this PR — the full suite (existing tests + the new ones) passes in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017c2hPZEx5nz6Z86Pk2d6Jw