### PR TITLE
fix: close two GA4 tracking gaps found in UX analytics review

### DIFF
--- a/src/views/SongSearch.vue
+++ b/src/views/SongSearch.vue
@@ -24,18 +24,29 @@ const pageSize = 10;
 const searchString = ref('');
 const totalCount = ref(0);
 
-// Only report search_no_results once the user has settled on a query. LxList
-// debounces keystrokes into search calls, but a brief pause mid-typing still
-// completes a search, so partial terms (e.g. "Cir", "Circ", "Circen") were all
-// logged as no-result searches. Defer the event and cancel it if another search
-// starts first, so only the query the user actually stopped on is reported.
-const NO_RESULTS_EVENT_DELAY = 2000;
-let noResultsTimer = null;
-function cancelNoResultsEvent() {
-  if (noResultsTimer) {
-    clearTimeout(noResultsTimer);
-    noResultsTimer = null;
+// Only report a search/search_no_results event once the user has settled on a
+// query. LxList's debounce (useSearchDebounce in Toolbar.vue) only applies to
+// searchSide="client" — for searchSide="server" (this list), @update:search-string
+// fires on every keystroke, so every partial term (e.g. "Cir", "Circ", "Circen")
+// was logged as its own event, whether or not it happened to have results. Defer
+// the event and cancel it if another search starts first, so only the query the
+// user actually stopped on is reported. This does not debounce the underlying
+// search API call itself — that still fires per keystroke and relies on
+// akordiService's abort-previous-request behaviour, which is fine for the UI but
+// deliberately not what GA sees here.
+const SEARCH_EVENT_SETTLE_DELAY = 2000;
+let searchEventTimer = null;
+function cancelPendingSearchEvent() {
+  if (searchEventTimer) {
+    clearTimeout(searchEventTimer);
+    searchEventTimer = null;
   }
+}
+function reportSearchEvent(name, term) {
+  searchEventTimer = setTimeout(() => {
+    event(name, { search_term: term });
+    searchEventTimer = null;
+  }, SEARCH_EVENT_SETTLE_DELAY);
 }
 
 function titleOrHighlight(song) {
@@ -55,8 +66,8 @@ async function search(q, more = false) {
   if (!more) {
     totalCount.value = 0;
     // A fresh query means the user kept typing/searching, so drop any
-    // no-results event still pending from the previous term.
-    cancelNoResultsEvent();
+    // event still pending from the previous term.
+    cancelPendingSearchEvent();
   }
   if (!q) {
     items.value = [];
@@ -74,18 +85,13 @@ async function search(q, more = false) {
         skip: more ? items.value.length : 0,
       });
     }
-    // One event per completed server search (LxList debounces input). !more = a fresh query, not paging.
+    // !more = a fresh query, not a "load more" page; only fresh queries are
+    // reported, and only after SEARCH_EVENT_SETTLE_DELAY of no follow-up query.
     if (resp.data.value.length === 0) {
-      if (!more) {
-        // Defer so a term the user is still typing past doesn't get logged.
-        noResultsTimer = setTimeout(() => {
-          event('search_no_results', { search_term: q });
-          noResultsTimer = null;
-        }, NO_RESULTS_EVENT_DELAY);
-      }
+      if (!more) reportSearchEvent('search_no_results', q);
       return;
     }
-    if (!more) event('search', { search_term: q });
+    if (!more) reportSearchEvent('search', q);
     totalCount.value = resp.data['@odata.count'];
     const results = resp.data.value.map((song) => ({
       ...song,
@@ -154,7 +160,7 @@ onMounted(async () => {
 });
 onUnmounted(() => {
   // Don't fire for a query the user abandoned by navigating away.
-  cancelNoResultsEvent();
+  cancelPendingSearchEvent();
 });
 </script>
 <style>

--- a/src/views/SongView.vue
+++ b/src/views/SongView.vue
@@ -279,6 +279,20 @@ const loadSong = async () => {
   try {
     playAlong.value = false;
     const songId = akordiService.parseUrl(songUrlParam.value);
+
+    // Fire the landing page_view from the route itself, before the song API
+    // call, not after it. Song routes are excluded from vue-gtag's automatic
+    // router pageTracker (so the real song title can be sent instead of a
+    // generic one), but that meant this was the only page_view for the
+    // highest-traffic entry point (SEO song landings) — and it was gated
+    // behind a full network round trip. A visitor who bounces before that
+    // response arrives left with no page_view at all, showing up in GA as a
+    // "(not set)" landing page with ~0% engagement instead of a real bounce
+    // on this song's URL.
+    const pagePath = `/song/${songUrlParam.value}`;
+    const canonicalUrl = `${window.location.origin}${pagePath}`;
+    pageview({ page_path: pagePath, page_location: canonicalUrl });
+
     const resp = await akordiService.getSong(songId);
     item.value = resp.data;
     item.value.createdAt = lxDateUtils.formatDate(item.value.createdDate);
@@ -293,8 +307,6 @@ const loadSong = async () => {
     }
     applyTranspose(transposeOffset);
 
-    const pagePath = `/song/${songUrlParam.value}`;
-    const canonicalUrl = `${window.location.origin}${pagePath}`;
     const pageTitle = `${item.value.mainArtist.title} - ${item.value.title}`;
     if (pagePath !== item.value.url) {
       const songUrl = item.value.url.replace(/^\/song\//, '');
@@ -303,8 +315,6 @@ const loadSong = async () => {
         params: { url: songUrl },
       });
     }
-
-    pageview({ page_path: pagePath, page_location: canonicalUrl, page_title: pageTitle });
 
     const metaDescription = item.value.bodyLyrics?.slice(0, 150) || '';
 

--- a/tests/unit/songSearch.test.js
+++ b/tests/unit/songSearch.test.js
@@ -53,7 +53,27 @@ afterEach(() => {
   vi.useRealTimers();
 });
 
-describe('SongSearch — search_no_results reporting', () => {
+describe('SongSearch — search / search_no_results reporting', () => {
+  it('reports only the term the user settles on for a successful search, not the prefixes typed through', async () => {
+    search.mockResolvedValue(withResults());
+    const wrapper = mount(SongSearch);
+
+    // Every one of these keystrokes independently returns results (the API
+    // has no debounce), so pre-fix each one fired its own "search" event.
+    await type(wrapper, 'D');
+    await type(wrapper, 'Da');
+    await type(wrapper, 'Dak');
+    await type(wrapper, 'Dakota');
+
+    expect(gtagEvent).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(2000);
+
+    const searchCalls = gtagEvent.mock.calls.filter((c) => c[0] === 'search');
+    expect(searchCalls).toHaveLength(1);
+    expect(searchCalls[0][1]).toEqual({ search_term: 'Dakota' });
+  });
+
   it('reports only the term the user settles on, not the prefixes typed through', async () => {
     search.mockResolvedValue(noResults());
     const wrapper = mount(SongSearch);


### PR DESCRIPTION
- SongView: fire the landing page_view from the route immediately, before the song API call, instead of after it. Song routes are excluded from vue-gtag's automatic router pageTracker, so this manual call was the only page_view for SEO song landings — the site's highest-traffic entry point. Gating it behind a network round trip meant fast bounces recorded no page_view at all, showing up in GA as a "(not set)" landing page with ~0% engagement (14.5% of all sessions in the last 90 days) instead of a real, attributable bounce.

- SongSearch: extend the 2026-07-29 search_no_results settle-timer (PR #46) to the successful "search" event too. That fix only covered no-results searches; "search" still fired on every keystroke, which is what produced the single-letter search_term noise (M, D, K, T, S…) seen in the GA4 data, since most partial prefixes return some result. LxList's own debounce only applies to searchSide="client", never "server", so this view can't rely on it.

Adds a regression test pinning down the per-keystroke "search" event bug that would have failed before this fix.