### PR TITLE
Stop the song form submitting an edit as a new song

### DIFF
--- a/src/views/SongEdit.vue
+++ b/src/views/SongEdit.vue
@@ -99,8 +99,12 @@ const loadCopyFrom = async () => {
       title: i.title,
     }));
   } catch (err) {
+    // The user has been told; rethrowing from an async onMounted only turns this
+    // into an unhandled rejection and skips the rest of the hook (tags never
+    // load). The form stays without a song id, which the save guard rejects.
     notificationStore.pushError($t('errors.loadSongFailed'));
-    throw err;
+    // eslint-disable-next-line no-console
+    console.error(err);
   } finally {
     loading.value = false;
   }
@@ -152,6 +156,13 @@ async function actionClicked(actionName) {
     const isFormCorrect = await v.value.$validate();
     if (!isFormCorrect) {
       notify.pushError($t('error.validation'));
+      return;
+    }
+    // An edit whose song never loaded (failed fetch, unknown id) would be
+    // submitted with no id and land in the queue as a new song, so refuse it
+    // rather than silently turning an edit into a duplicate.
+    if (!props.isNew && !item.value.id) {
+      notify.pushError($t('errors.loadSongFailed'));
       return;
     }
     try {
@@ -233,7 +244,28 @@ async function loadTags() {
   }
 }
 
+// The form takes its mode from the route (/add is a new song, /edit is an edit)
+// but its target song from ?id=, and nothing used to reconcile the two: /add
+// ignored the id, so a submission from that URL was stored as a brand new song
+// instead of an edit of the song it named, and /edit without an id offered a
+// blank form that submitted the same way. Send each URL to the route that
+// matches what it is actually asking for before the form renders.
+const routeModeMismatch = async () => {
+  if (props.isNew && idParam.value) {
+    await router.replace({ name: 'songEdit', query: { id: idParam.value } });
+    return true;
+  }
+  if (!props.isNew && !idParam.value) {
+    await router.replace({ name: 'songNew' });
+    return true;
+  }
+  return false;
+};
+
 onMounted(async () => {
+  if (await routeModeMismatch()) {
+    return;
+  }
   viewStore.$reset();
   viewStore.goBack = true;
   if (props.isNew) {

--- a/tests/unit/songEditMode.test.js
+++ b/tests/unit/songEditMode.test.js
@@ -1,0 +1,151 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { mount, flushPromises } from '@vue/test-utils';
+
+const { getSong, getTags, saveEdit, replace, push, back, pushError, query } = vi.hoisted(() => ({
+  getSong: vi.fn(),
+  getTags: vi.fn(),
+  saveEdit: vi.fn(),
+  replace: vi.fn(),
+  push: vi.fn(),
+  back: vi.fn(),
+  pushError: vi.fn(),
+  query: { value: {} },
+}));
+
+// Stub the lx-ui pieces the form uses; LxForm captures the save/cancel action.
+vi.mock('@dativa-lv/lx-ui', () => {
+  const passthrough = (name) => ({ name, template: '<div><slot /></div>' });
+  return {
+    LxForm: {
+      name: 'LxForm',
+      props: ['actionDefinitions'],
+      emits: ['action-click'],
+      template: '<div><slot /></div>',
+    },
+    LxRow: passthrough('LxRow'),
+    LxAutoComplete: { name: 'LxAutoComplete', props: ['modelValue'], template: '<div />' },
+    LxTextInput: { name: 'LxTextInput', props: ['modelValue'], template: '<input />' },
+    LxTextArea: { name: 'LxTextArea', props: ['modelValue'], template: '<textarea />' },
+    LxValuePicker: { name: 'LxValuePicker', props: ['modelValue'], template: '<div />' },
+  };
+});
+vi.mock('@/services/akordiService', () => ({
+  default: { getSong, getTags, saveEdit, searchArtist: vi.fn() },
+}));
+vi.mock('vue-i18n', () => ({ useI18n: () => ({ t: (key) => key }) }));
+vi.mock('vue-router', () => ({
+  useRoute: () => ({ query: query.value }),
+  useRouter: () => ({ replace, push, back }),
+}));
+vi.mock('@/stores/useViewStore', () => ({
+  default: () => ({ title: '', description: '', goBack: false, $reset: vi.fn() }),
+}));
+vi.mock('@/stores/useNotifyStore', () => ({
+  default: () => ({ pushError, pushSuccess: vi.fn() }),
+}));
+// The template reads v.<field>.$error for every field, so hand back a ref whose
+// unknown properties answer as a clean, untouched validator.
+vi.mock('@vuelidate/core', async () => {
+  const { ref } = await import('vue');
+  const validator = new Proxy(
+    { $validate: () => Promise.resolve(true), $reset: () => {} },
+    {
+      get(target, prop) {
+        if (prop in target) {
+          return target[prop];
+        }
+        return { $error: false, $errors: [] };
+      },
+    },
+  );
+  return { default: () => ref(validator) };
+});
+vi.mock('@vuelidate/validators', () => ({
+  createI18nMessage: () => (rule) => rule,
+  required: () => true,
+}));
+
+const songResponse = {
+  data: {
+    id: 5237,
+    title: 'Pirmajā dienā',
+    body: 'body with chords',
+    mainArtist: { id: 1, title: 'Prāta Vētra/Brainstorm' },
+    composers: [],
+    poets: [],
+    performers: [],
+    tags: [],
+  },
+};
+
+async function mountForm(isNew) {
+  const SongEdit = (await import('@/views/SongEdit.vue')).default;
+  const wrapper = mount(SongEdit, { props: { isNew } });
+  await flushPromises();
+  return wrapper;
+}
+
+async function save(wrapper) {
+  wrapper.findComponent({ name: 'LxForm' }).vm.$emit('action-click', 'save');
+  await flushPromises();
+}
+
+describe('public song form new-vs-edit mode', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    query.value = {};
+    getTags.mockResolvedValue({ data: { content: [] } });
+    getSong.mockResolvedValue(songResponse);
+    saveEdit.mockResolvedValue({ data: { id: 1 } });
+  });
+
+  it('sends /add?id= to the edit route so it is not submitted as a new song', async () => {
+    query.value = { id: '5237' };
+    await mountForm(true);
+
+    expect(replace).toHaveBeenCalledWith({ name: 'songEdit', query: { id: '5237' } });
+    // Nothing is loaded or submitted from the mismatched route.
+    expect(getSong).not.toHaveBeenCalled();
+  });
+
+  it('sends /edit with no id to the new-song route', async () => {
+    await mountForm(false);
+
+    expect(replace).toHaveBeenCalledWith({ name: 'songNew' });
+    expect(getSong).not.toHaveBeenCalled();
+  });
+
+  it('leaves /add alone and submits without a song id', async () => {
+    const wrapper = await mountForm(true);
+    expect(replace).not.toHaveBeenCalled();
+
+    // The main artist is the only field the submit mapping needs.
+    wrapper.findAllComponents({ name: 'LxAutoComplete' })[0].vm.$emit('update:modelValue', '1');
+    await flushPromises();
+
+    await save(wrapper);
+    expect(saveEdit).toHaveBeenCalledTimes(1);
+    expect(saveEdit.mock.calls[0][0].id).toBeUndefined();
+  });
+
+  it('submits /edit?id= as an edit carrying the song id', async () => {
+    query.value = { id: '5237' };
+    const wrapper = await mountForm(false);
+    expect(replace).not.toHaveBeenCalled();
+    expect(getSong).toHaveBeenCalledWith('5237');
+
+    await save(wrapper);
+    expect(saveEdit).toHaveBeenCalledTimes(1);
+    expect(saveEdit.mock.calls[0][0].id).toBe(5237);
+  });
+
+  it('refuses to submit an edit whose song failed to load', async () => {
+    query.value = { id: '5237' };
+    getSong.mockRejectedValue(new Error('boom'));
+    const wrapper = await mountForm(false);
+
+    await save(wrapper);
+    expect(saveEdit).not.toHaveBeenCalled();
+    expect(pushError).toHaveBeenCalledWith('errors.loadSongFailed');
+  });
+});


### PR DESCRIPTION
## Why

`SongEdit.vue` takes its mode from the route — `/add` (`songNew`, `isNew=true`) is a new song, `/edit` (`songEdit`) is an edit — but takes its target song from `?id=`, and nothing reconciled the two:

- **`/add?id=42`** ignored the id (`onMounted` only calls `loadCopyFrom()` when `!isNew`), so the submission reached `POST /api/v2/edits` with `id: undefined`. The API stores that as id 0, which means the moderation queue holds it as a *brand new song* instead of an edit of song 42 — and approving it creates a duplicate.
- **`/edit` with no id** rendered a blank form titled "edit" that submitted exactly the same way.

The in-app links are fine (`SongView.vue:489` pushes `songEdit` with the id), so this only bites URLs that arrive from outside — shared or hand-edited links, and anything that ever pointed at `/add` while carrying a song id.

## What

- `routeModeMismatch()` runs before the form renders and `router.replace`s each URL to the route that matches what it is asking for: `/add?id=…` → `/edit?id=…`, `/edit` with no id → `/add`. Nothing loads or submits from the mismatched route.
- The save handler refuses an edit with no loaded song id, so a failed song fetch can no longer turn an edit into a duplicate. It reuses the existing `errors.loadSongFailed` message (present in all four locales).
- `loadCopyFrom` no longer rethrows after notifying the user. From an async `onMounted` that only produced an unhandled rejection and aborted the rest of the hook, so tags never loaded.

## Testing

New `tests/unit/songEditMode.test.js` covers all five paths: `/add?id=` redirects, `/edit` without an id redirects, `/add` submits with no id, `/edit?id=` submits carrying id 5237, and a failed load blocks submission. `bun run test` 42 passed, `bun run lint` clean, `bun run build` succeeds.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QH5zqrZN3UnFLkiQtY6HLK)_