### PR TITLE
Resume play-along and add a self-service chord generator page

### DIFF
--- a/src/locales/ee.json
+++ b/src/locales/ee.json
@@ -217,7 +217,48 @@
             "nextChord": "Järgmine",
             "changesIn": "pärast",
             "songEnd": "Laulu lõpp",
-            "seconds": "s"
+            "seconds": "s",
+            "generateOwn": "Sellel laulul pole akordide ajaskaalat? Proovi seda ise genereerida."
+        },
+        "chordGenerator": {
+            "title": "Akordigeneraator",
+            "description": "Lisa YouTube link ja tehisintellekt loob akordide ajaskaala, millega saad kaasa mängida.",
+            "empty": "Ühtegi genereeritud akordikirjet veel ei ole.",
+            "add": "Genereeri uus",
+            "submitTitle": "Genereeri akordid",
+            "form": {
+                "youtubeUrl": "YouTube link",
+                "artist": "Esitaja",
+                "title": "Laulu pealkiri",
+                "submit": "Genereeri"
+            },
+            "loginRequired": {
+                "title": "Sisselogimine on vajalik",
+                "message": "Uue laulu genereerimiseks esitamiseks pead esmalt sisse logima.",
+                "action": "Logi sisse"
+            },
+            "queue": {
+                "depth": "Järjekorras: {pending}, töötlemisel: {running}",
+                "eta": "Eeldatav ooteaeg: {eta}",
+                "none": "Järjekord on hetkel tühi"
+            },
+            "status": {
+                "pending": "Ootab järjekorras...",
+                "running": "Akordide genereerimine käib...",
+                "exists": "See laul on juba saadaval",
+                "rateLimited": "Esituste limiit on täis. Palun proovi hiljem uuesti.",
+                "error": "Akordide loomine ebaõnnestus"
+            },
+            "errors": {
+                "invalidUrl": "Sisesta kehtiv YouTube link",
+                "submitFailed": "Laulu esitamine ebaõnnestus",
+                "loadFailed": "Andmete laadimine ebaõnnestus"
+            },
+            "rating": {
+                "yours": "Sinu hinnang",
+                "average": "Keskmine hinnang",
+                "none": "Hinnanguid veel pole"
+            }
         },
         "akordiSongView": {
             "title": "Akordid.ee laulud",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -217,7 +217,48 @@
             "nextChord": "Siguiente",
             "changesIn": "en",
             "songEnd": "Fin de la canción",
-            "seconds": "s"
+            "seconds": "s",
+            "generateOwn": "¿No hay una línea de tiempo de acordes para esta canción? Prueba a generarla tú mismo."
+        },
+        "chordGenerator": {
+            "title": "Generador de acordes",
+            "description": "Pega un enlace de YouTube y la inteligencia artificial creará una línea de tiempo de acordes para que puedas tocar junto a ella.",
+            "empty": "Todavía no hay ninguna canción generada.",
+            "add": "Generar nueva",
+            "submitTitle": "Generar acordes",
+            "form": {
+                "youtubeUrl": "Enlace de YouTube",
+                "artist": "Artista",
+                "title": "Título de la canción",
+                "submit": "Generar"
+            },
+            "loginRequired": {
+                "title": "Se requiere iniciar sesión",
+                "message": "Para enviar una nueva canción a generar, primero debes iniciar sesión.",
+                "action": "Iniciar sesión"
+            },
+            "queue": {
+                "depth": "En cola: {pending}, en proceso: {running}",
+                "eta": "Tiempo de espera estimado: {eta}",
+                "none": "La cola está vacía en este momento"
+            },
+            "status": {
+                "pending": "Esperando en la cola...",
+                "running": "Generando los acordes...",
+                "exists": "Esta canción ya está disponible",
+                "rateLimited": "Se alcanzó el límite de envíos. Inténtalo más tarde.",
+                "error": "No se pudieron generar los acordes"
+            },
+            "errors": {
+                "invalidUrl": "Indica un enlace de YouTube válido",
+                "submitFailed": "No se pudo enviar la canción",
+                "loadFailed": "No se pudieron cargar los datos"
+            },
+            "rating": {
+                "yours": "Tu valoración",
+                "average": "Valoración media",
+                "none": "Todavía no hay valoraciones"
+            }
         },
         "akordiSongView": {
             "title": "Canciones de Akordi.es",

--- a/src/locales/lt.json
+++ b/src/locales/lt.json
@@ -217,7 +217,48 @@
             "nextChord": "Kitas",
             "changesIn": "po",
             "songEnd": "Dainos pabaiga",
-            "seconds": "s"
+            "seconds": "s",
+            "generateOwn": "Nėra akordų laiko juostos šiai dainai? Pabandyk sugeneruoti pats."
+        },
+        "chordGenerator": {
+            "title": "Akordų generatorius",
+            "description": "Įklijuok YouTube nuorodą, ir dirbtinis intelektas sukurs akordų laiko juostą, kuriai galėsi groti kartu.",
+            "empty": "Kol kas nėra nė vieno sugeneruoto akordų įrašo.",
+            "add": "Generuoti naują",
+            "submitTitle": "Generuoti akordus",
+            "form": {
+                "youtubeUrl": "YouTube nuoroda",
+                "artist": "Atlikėjas",
+                "title": "Dainos pavadinimas",
+                "submit": "Generuoti"
+            },
+            "loginRequired": {
+                "title": "Būtina prisijungti",
+                "message": "Norint pateikti naują dainą generavimui, pirmiausia reikia prisijungti.",
+                "action": "Prisijungti"
+            },
+            "queue": {
+                "depth": "Eilėje: {pending}, apdorojama: {running}",
+                "eta": "Numatomas laukimo laikas: {eta}",
+                "none": "Eilė šiuo metu tuščia"
+            },
+            "status": {
+                "pending": "Laukiama eilėje...",
+                "running": "Generuojami akordai...",
+                "exists": "Ši daina jau yra pridėta",
+                "rateLimited": "Pasiektas pateikimų limitas. Bandyk vėliau.",
+                "error": "Nepavyko sugeneruoti akordų"
+            },
+            "errors": {
+                "invalidUrl": "Nurodyk galiojančią YouTube nuorodą",
+                "submitFailed": "Nepavyko pateikti dainos",
+                "loadFailed": "Nepavyko įkelti duomenų"
+            },
+            "rating": {
+                "yours": "Tavo įvertinimas",
+                "average": "Vidutinis įvertinimas",
+                "none": "Kol kas nėra įvertinimų"
+            }
         },
         "akordiSongView": {
             "title": "Akordai.lt dainos",

--- a/src/locales/lv.json
+++ b/src/locales/lv.json
@@ -217,7 +217,48 @@
             "nextChord": "Nākamais",
             "changesIn": "pēc",
             "songEnd": "Dziesmas beigas",
-            "seconds": "s"
+            "seconds": "s",
+            "generateOwn": "Nav akordu laika skalas šai dziesmai? Izmēģini ģenerēt to pats."
+        },
+        "chordGenerator": {
+            "title": "Akordu ģenerators",
+            "description": "Ievieto YouTube saiti un mākslīgais intelekts izveidos akordu laika skalu, kurai vari spēlēt līdzi.",
+            "empty": "Vēl nav neviena ģenerēta akordu ieraksta.",
+            "add": "Ģenerēt jaunu",
+            "submitTitle": "Ģenerēt akordus",
+            "form": {
+                "youtubeUrl": "YouTube saite",
+                "artist": "Izpildītājs",
+                "title": "Dziesmas nosaukums",
+                "submit": "Ģenerēt"
+            },
+            "loginRequired": {
+                "title": "Nepieciešama pieslēgšanās",
+                "message": "Lai iesniegtu jaunu dziesmu ģenerēšanai, vispirms jāpieslēdzas.",
+                "action": "Pieslēgties"
+            },
+            "queue": {
+                "depth": "Rindā: {pending}, apstrādē: {running}",
+                "eta": "Aptuvenais gaidīšanas laiks: {eta}",
+                "none": "Rinda pašlaik ir tukša"
+            },
+            "status": {
+                "pending": "Rindā gaida apstrādi...",
+                "running": "Tiek ģenerēti akordi...",
+                "exists": "Šī dziesma jau ir pieejama",
+                "rateLimited": "Sasniegts iesniegumu limits. Lūdzu, mēģini vēlāk.",
+                "error": "Neizdevās izveidot akordus"
+            },
+            "errors": {
+                "invalidUrl": "Norādi derīgu YouTube saiti",
+                "submitFailed": "Neizdevās iesniegt dziesmu",
+                "loadFailed": "Neizdevās ielādēt datus"
+            },
+            "rating": {
+                "yours": "Tavs vērtējums",
+                "average": "Vidējais vērtējums",
+                "none": "Vēl nav vērtējumu"
+            }
         },
         "akordiSongView": {
             "title": "Akordi.lv dziesmas",

--- a/src/router/routes.js
+++ b/src/router/routes.js
@@ -276,6 +276,31 @@ const routes = [
         },
         component: () => import('@/views/SongView.vue'),
       },
+      {
+        path: '/akordu-generators',
+        name: 'chordGeneratorList',
+        meta: { title: 'pages.chordGenerator.title', anonymous: true },
+        component: () => import('@/views/ChordGeneratorList.vue'),
+      },
+      {
+        path: '/akordu-generators/jauns',
+        name: 'chordGeneratorSubmit',
+        meta: {
+          title: 'pages.chordGenerator.submitTitle',
+          anonymous: true,
+          breadcrumbs: [{ text: 'pages.chordGenerator.title', to: { name: 'chordGeneratorList' } }],
+        },
+        component: () => import('@/views/ChordGeneratorSubmit.vue'),
+      },
+      {
+        path: '/akordu-generators/:id',
+        name: 'chordGeneratorView',
+        meta: {
+          anonymous: true,
+          breadcrumbs: [{ text: 'pages.chordGenerator.title', to: { name: 'chordGeneratorList' } }],
+        },
+        component: () => import('@/views/ChordGeneratorView.vue'),
+      },
 
       {
         path: '/error',

--- a/src/services/chordgenSongService.js
+++ b/src/services/chordgenSongService.js
@@ -1,0 +1,36 @@
+import http from '@/services/http';
+import httpAnon from '@/services/httpAnon';
+
+const serviceUrl = '/api/v2';
+
+export default {
+  // Public — no auth required.
+  findAll(params) {
+    return httpAnon(serviceUrl).get('/chordgen-songs', { params });
+  },
+
+  findOne(id) {
+    return httpAnon(serviceUrl).get(`/chordgen-songs/${id}`);
+  },
+
+  getQueue() {
+    return httpAnon(serviceUrl).get('/chordgen-songs/queue');
+  },
+
+  // Authenticated — requires a Kratos session.
+  submit(payload) {
+    return http(serviceUrl).post('/me/chordgen-songs', payload);
+  },
+
+  getMyJob(jobId) {
+    return http(serviceUrl).get(`/me/chordgen-songs/jobs/${jobId}`);
+  },
+
+  getMyRating(id) {
+    return http(serviceUrl).get(`/me/chordgen-songs/${id}/rating`);
+  },
+
+  submitRating(id, rating) {
+    return http(serviceUrl).put(`/me/chordgen-songs/${id}/rating`, { rating });
+  },
+};

--- a/src/views/ChordGeneratorList.vue
+++ b/src/views/ChordGeneratorList.vue
@@ -1,0 +1,103 @@
+<script setup>
+import chordgenSongService from '@/services/chordgenSongService';
+import { LxButton, LxList, LxRating } from '@dativa-lv/lx-ui';
+import { onMounted, ref } from 'vue';
+import { useI18n } from 'vue-i18n';
+import { useRouter } from 'vue-router';
+import useNotifyStore from '@/stores/useNotifyStore';
+import useViewStore from '@/stores/useViewStore';
+
+const router = useRouter();
+const $t = useI18n().t;
+const viewStore = useViewStore();
+const notificationStore = useNotifyStore();
+const items = ref([]);
+const loading = ref(true);
+const hasMore = ref(false);
+const page = ref(0);
+const PAGE_SIZE = 20;
+
+function mapSong(song) {
+  return {
+    ...song,
+    id: String(song.id),
+    title: `${song.artist} — ${song.title}`,
+    averageRating: song.averageRating ?? 0,
+    ratingsCount: song.ratingsCount ?? 0,
+    clickable: true,
+  };
+}
+
+// Always newest-first, exactly as returned by the API — never re-sorted
+// client-side, even though rating is displayed alongside each entry.
+async function loadItems() {
+  try {
+    loading.value = true;
+    const resp = await chordgenSongService.findAll({ size: PAGE_SIZE, page: page.value });
+    const mapped = resp.data.content.map(mapSong);
+    if (page.value === 0) {
+      items.value = mapped;
+    } else {
+      items.value.push(...mapped);
+    }
+    hasMore.value = items.value.length < resp.data.totalElements;
+  } catch (err) {
+    notificationStore.pushError($t('pages.chordGenerator.errors.loadFailed'));
+  } finally {
+    loading.value = false;
+  }
+}
+
+function loadMore() {
+  page.value += 1;
+  loadItems();
+}
+
+function actionClicked(action, id) {
+  if (action === 'click') {
+    router.push({ name: 'chordGeneratorView', params: { id } });
+  }
+}
+
+onMounted(async () => {
+  viewStore.title = $t('pages.chordGenerator.title');
+  viewStore.description = $t('pages.chordGenerator.description');
+  viewStore.goBack = true;
+  await loadItems();
+});
+</script>
+
+<template>
+  <LxList
+    id="chordGeneratorList"
+    list-type="2"
+    v-model:items="items"
+    id-attribute="id"
+    :loading="loading"
+    :show-load-more="hasMore"
+    @load-more="loadMore"
+    @action-click="actionClicked"
+  >
+    <template #toolbar>
+      <LxButton
+        icon="add"
+        :label="$t('pages.chordGenerator.add')"
+        @click="router.push({ name: 'chordGeneratorSubmit' })"
+      />
+    </template>
+    <template #customItem="{ title, averageRating, ratingsCount }">
+      <p class="lx-primary">{{ title }}</p>
+      <div class="lx-secondary" style="display: flex; align-items: center; gap: 0.35rem">
+        <LxRating :model-value="averageRating" read-only kind="5stars" :focusable="false" />
+        <span>{{
+          ratingsCount > 0
+            ? `${averageRating.toFixed(1)} (${ratingsCount})`
+            : $t('pages.chordGenerator.rating.none')
+        }}</span>
+      </div>
+    </template>
+    <template #empty>
+      {{ $t('pages.chordGenerator.empty') }}
+    </template>
+  </LxList>
+</template>

--- a/src/views/ChordGeneratorSubmit.vue
+++ b/src/views/ChordGeneratorSubmit.vue
@@ -1,0 +1,309 @@
+<script setup>
+import { LxButton, LxForm, LxInfoBox, LxRow, LxTextInput } from '@dativa-lv/lx-ui';
+import { computed, onMounted, onUnmounted, ref } from 'vue';
+import { useI18n } from 'vue-i18n';
+import { useRoute, useRouter } from 'vue-router';
+import useVuelidate from '@vuelidate/core';
+import * as validations from '@vuelidate/validators';
+
+import chordgenSongService from '@/services/chordgenSongService';
+import useAuthStore from '@/stores/useAuthStore';
+import useNotifyStore from '@/stores/useNotifyStore';
+import useViewStore from '@/stores/useViewStore';
+
+const $t = useI18n().t;
+const route = useRoute();
+const router = useRouter();
+const viewStore = useViewStore();
+const notificationStore = useNotifyStore();
+const authStore = useAuthStore();
+const isAuthorized = authStore.isAuthenticated();
+
+const withI18nMessage = validations.createI18nMessage({ t: $t });
+const required = withI18nMessage(validations.required);
+const isUrl = withI18nMessage(validations.url);
+
+const item = ref({ youtubeUrl: '', artist: '', title: '' });
+const rules = {
+  youtubeUrl: { required, url: isUrl },
+  artist: { required },
+  title: { required },
+};
+const v = useVuelidate(rules, item);
+
+const submitting = ref(false);
+const jobStatus = ref(null);
+const queue = ref(null);
+
+const POLL_INTERVAL_MS = 3000;
+const POLL_TIMEOUT_MS = 20 * 60 * 1000;
+let pollTimer = null;
+let pollDeadline = null;
+
+const formActions = computed(() => [
+  {
+    id: 'submit',
+    icon: 'add',
+    name: $t('pages.chordGenerator.form.submit'),
+    kind: 'primary',
+    busy: submitting.value,
+  },
+  { id: 'cancel', icon: 'cancel', name: $t('cancel'), kind: 'secondary' },
+]);
+
+// Small, best-effort banner text — no library, just enough to be human-friendly.
+function formatWait(seconds) {
+  if (!seconds || seconds <= 0) {
+    return null;
+  }
+  if (seconds < 60) {
+    return '< 1 min';
+  }
+  return `~${Math.round(seconds / 60)} min`;
+}
+
+const queueMessage = computed(() => {
+  if (!queue.value) {
+    return '';
+  }
+  const pending = queue.value.pending || 0;
+  const running = queue.value.running || 0;
+  if (pending === 0 && running === 0) {
+    return $t('pages.chordGenerator.queue.none');
+  }
+  const depth = $t('pages.chordGenerator.queue.depth', { pending, running });
+  const wait = formatWait(queue.value.estimatedWaitSeconds);
+  if (!wait) {
+    return depth;
+  }
+  return `${depth} · ${$t('pages.chordGenerator.queue.eta', { eta: wait })}`;
+});
+
+const submittingMessage = computed(() => {
+  if (!jobStatus.value) {
+    return '';
+  }
+  if (jobStatus.value.status === 'running') {
+    return $t('pages.chordGenerator.status.running');
+  }
+  if (jobStatus.value.status === 'pending') {
+    if (jobStatus.value.queueAhead != null) {
+      return `${$t('pages.chordGenerator.status.pending')} (${jobStatus.value.queueAhead})`;
+    }
+    return $t('pages.chordGenerator.status.pending');
+  }
+  return '';
+});
+
+async function loadQueue() {
+  try {
+    const resp = await chordgenSongService.getQueue();
+    queue.value = resp.data;
+  } catch (err) {
+    // Non-critical banner — a failed fetch just means no banner is shown.
+  }
+}
+
+// Best-effort YouTube oEmbed autofill: only kicks in when the URL is filled
+// but artist+title are still both empty (i.e. no query prefill happened).
+// Any failure (network, non-200, no separator match) is silently ignored —
+// this must never block or error the form.
+function splitArtistTitle(rawTitle) {
+  const separators = [' - ', ' – ', ' — '];
+  const sep = separators.find((candidate) => rawTitle.includes(candidate));
+  if (!sep) {
+    return null;
+  }
+  const idx = rawTitle.indexOf(sep);
+  return {
+    artist: rawTitle.slice(0, idx).trim(),
+    title: rawTitle.slice(idx + sep.length).trim(),
+  };
+}
+
+async function onYoutubeUrlBlur() {
+  if (!item.value.youtubeUrl || item.value.artist || item.value.title) {
+    return;
+  }
+  try {
+    const resp = await fetch(
+      `https://www.youtube.com/oembed?url=${encodeURIComponent(item.value.youtubeUrl)}&format=json`
+    );
+    if (!resp.ok) {
+      return;
+    }
+    const data = await resp.json();
+    const guess = data?.title ? splitArtistTitle(data.title) : null;
+    if (!guess) {
+      return;
+    }
+    if (!item.value.artist && guess.artist) {
+      item.value.artist = guess.artist;
+    }
+    if (!item.value.title && guess.title) {
+      item.value.title = guess.title;
+    }
+  } catch (err) {
+    // Silently ignore — best-effort only.
+  }
+}
+
+function stopPolling() {
+  if (pollTimer) {
+    clearInterval(pollTimer);
+    pollTimer = null;
+  }
+}
+
+async function pollJob(jobId) {
+  if (Date.now() > pollDeadline) {
+    stopPolling();
+    submitting.value = false;
+    notificationStore.pushError($t('pages.chordGenerator.status.error'));
+    return;
+  }
+  try {
+    const resp = await chordgenSongService.getMyJob(jobId);
+    const { data } = resp;
+    if (data.status === 'done') {
+      stopPolling();
+      submitting.value = false;
+      router.push({ name: 'chordGeneratorView', params: { id: data.songId } });
+      return;
+    }
+    if (data.status === 'error') {
+      stopPolling();
+      submitting.value = false;
+      notificationStore.pushError(data.error || $t('pages.chordGenerator.status.error'));
+      return;
+    }
+    jobStatus.value = data;
+  } catch (err) {
+    // Transient poll failure — keep trying until the deadline.
+  }
+}
+
+function startPolling(jobId) {
+  pollDeadline = Date.now() + POLL_TIMEOUT_MS;
+  stopPolling();
+  pollJob(jobId);
+  pollTimer = setInterval(() => pollJob(jobId), POLL_INTERVAL_MS);
+}
+
+async function onSubmit() {
+  const isValid = await v.value.$validate();
+  if (!isValid) {
+    notificationStore.pushError($t('error.validation'));
+    return;
+  }
+  submitting.value = true;
+  jobStatus.value = null;
+  try {
+    const resp = await chordgenSongService.submit({
+      youtubeUrl: item.value.youtubeUrl,
+      artist: item.value.artist,
+      title: item.value.title,
+    });
+    const { data } = resp;
+    if (data.status === 'pending') {
+      jobStatus.value = { status: 'pending' };
+      startPolling(data.id);
+      return;
+    }
+    if (data.status === 'exists' || data.status === 'cached') {
+      submitting.value = false;
+      router.push({ name: 'chordGeneratorView', params: { id: data.song.id } });
+      return;
+    }
+    submitting.value = false;
+  } catch (err) {
+    submitting.value = false;
+    if (err?.response?.status === 429) {
+      notificationStore.pushError($t('pages.chordGenerator.status.rateLimited'));
+      return;
+    }
+    notificationStore.pushError($t('pages.chordGenerator.errors.submitFailed'));
+  }
+}
+
+function actionClicked(actionName) {
+  if (actionName === 'submit') {
+    onSubmit();
+  } else if (actionName === 'cancel') {
+    router.push({ name: 'chordGeneratorList' });
+  }
+}
+
+onMounted(async () => {
+  viewStore.title = $t('pages.chordGenerator.submitTitle');
+  viewStore.goBack = true;
+  if (route.query.youtubeUrl) {
+    item.value.youtubeUrl = String(route.query.youtubeUrl);
+  }
+  if (route.query.artist) {
+    item.value.artist = String(route.query.artist);
+  }
+  if (route.query.title) {
+    item.value.title = String(route.query.title);
+  }
+  if (isAuthorized) {
+    await loadQueue();
+  }
+});
+
+onUnmounted(() => {
+  stopPolling();
+});
+</script>
+
+<template>
+  <template v-if="!isAuthorized">
+    <LxInfoBox
+      :label="$t('pages.chordGenerator.loginRequired.title')"
+      :description="$t('pages.chordGenerator.loginRequired.message')"
+      variant="info"
+    />
+    <LxButton
+      kind="primary"
+      icon="next"
+      :label="$t('pages.chordGenerator.loginRequired.action')"
+      @click="authStore.login(route.fullPath)"
+    />
+  </template>
+  <template v-else>
+    <LxInfoBox v-if="queueMessage" :label="queueMessage" variant="info" />
+    <LxForm
+      :action-definitions="formActions"
+      @action-click="actionClicked"
+      :show-header="false"
+      required-mode="required-asterisk"
+    >
+      <LxRow :label="$t('pages.chordGenerator.form.youtubeUrl')" :required="true">
+        <LxTextInput
+          id="chordGenYoutubeUrlInput"
+          v-model="item.youtubeUrl"
+          :invalid="v.youtubeUrl.$error"
+          :invalidation-message="v.youtubeUrl.$error ? v.youtubeUrl.$errors[0].$message : ''"
+          @blur="onYoutubeUrlBlur"
+        />
+      </LxRow>
+      <LxRow :label="$t('pages.chordGenerator.form.artist')" :required="true">
+        <LxTextInput
+          id="chordGenArtistInput"
+          v-model="item.artist"
+          :invalid="v.artist.$error"
+          :invalidation-message="v.artist.$error ? v.artist.$errors[0].$message : ''"
+        />
+      </LxRow>
+      <LxRow :label="$t('pages.chordGenerator.form.title')" :required="true">
+        <LxTextInput
+          id="chordGenTitleInput"
+          v-model="item.title"
+          :invalid="v.title.$error"
+          :invalidation-message="v.title.$error ? v.title.$errors[0].$message : ''"
+        />
+      </LxRow>
+    </LxForm>
+    <p class="lx-description" v-if="submittingMessage">{{ submittingMessage }}</p>
+  </template>
+</template>

--- a/src/views/ChordGeneratorView.vue
+++ b/src/views/ChordGeneratorView.vue
@@ -1,0 +1,94 @@
+<script setup>
+import { LxLoaderView, LxRating } from '@dativa-lv/lx-ui';
+import { computed, onMounted, ref } from 'vue';
+import { useI18n } from 'vue-i18n';
+import { useRoute } from 'vue-router';
+
+import ChordPlayer from '@/components/ChordPlayer.vue';
+import chordgenSongService from '@/services/chordgenSongService';
+import useAuthStore from '@/stores/useAuthStore';
+import useNotifyStore from '@/stores/useNotifyStore';
+import useViewStore from '@/stores/useViewStore';
+
+const $t = useI18n().t;
+const route = useRoute();
+const viewStore = useViewStore();
+const notificationStore = useNotifyStore();
+const authStore = useAuthStore();
+const isAuthorized = authStore.isAuthenticated();
+
+const loading = ref(true);
+const song = ref({});
+const myRating = ref(null);
+
+const ratingSummary = computed(() => {
+  if (!song.value.ratingsCount) {
+    return $t('pages.chordGenerator.rating.none');
+  }
+  return `${(song.value.averageRating || 0).toFixed(1)} (${song.value.ratingsCount})`;
+});
+
+async function loadSong() {
+  try {
+    loading.value = true;
+    const resp = await chordgenSongService.findOne(route.params.id);
+    song.value = resp.data;
+    viewStore.title = `${song.value.artist} — ${song.value.title}`;
+    viewStore.goBack = true;
+  } catch (err) {
+    notificationStore.pushError($t('pages.chordGenerator.errors.loadFailed'));
+  } finally {
+    loading.value = false;
+  }
+}
+
+async function loadMyRating() {
+  try {
+    const resp = await chordgenSongService.getMyRating(route.params.id);
+    myRating.value = resp.data.rating ?? null;
+  } catch (err) {
+    // Own-rating fetch is a nice-to-have — leave the control unset on failure.
+  }
+}
+
+async function onRate(value) {
+  const previous = myRating.value;
+  myRating.value = value;
+  try {
+    const resp = await chordgenSongService.submitRating(route.params.id, value);
+    song.value.averageRating = resp.data.averageRating;
+    song.value.ratingsCount = resp.data.ratingsCount;
+  } catch (err) {
+    myRating.value = previous;
+    notificationStore.pushError($t('pages.chordGenerator.errors.submitFailed'));
+  }
+}
+
+onMounted(async () => {
+  await loadSong();
+  if (isAuthorized) {
+    await loadMyRating();
+  }
+});
+</script>
+
+<template>
+  <LxLoaderView :loading="loading">
+    <p class="lx-primary">{{ song.artist }} — {{ song.title }}</p>
+
+    <ChordPlayer :video-url="song.youtubeUrl" :segments="song.segments" :duration="song.duration" />
+
+    <div style="display: flex; align-items: center; gap: 0.5rem; margin-top: 1rem">
+      <LxRating :model-value="song.averageRating || 0" read-only kind="5stars" :focusable="false" />
+      <span class="lx-secondary">{{ ratingSummary }}</span>
+    </div>
+
+    <div
+      v-if="isAuthorized"
+      style="display: flex; align-items: center; gap: 0.5rem; margin-top: 0.5rem"
+    >
+      <span class="lx-label">{{ $t('pages.chordGenerator.rating.yours') }}</span>
+      <LxRating :model-value="myRating || 0" kind="5stars" @update:model-value="onRate" />
+    </div>
+  </LxLoaderView>
+</template>

--- a/src/views/SongView.vue
+++ b/src/views/SongView.vue
@@ -69,8 +69,16 @@ const segments = computed(() => item.value.chordTimeline?.segments ?? []);
 const duration = computed(() => item.value.chordTimeline?.duration ?? 0);
 // A song is playable only with a resolvable video AND at least one chord segment.
 const playable = computed(() => !!youtubeId(videoUrl.value) && segments.value.length > 0);
-// ponytail: play-along hidden from frontend for now — flip to true to re-enable the entry CTA.
-const playAlongEnabled = false;
+const playAlongEnabled = true;
+// Prefills the self-service chord generator with what we already know about
+// this song, for the "generate your own" entry point shown when it's not playable.
+const generateOwnQuery = computed(() => {
+  const q = {};
+  if (item.value.youtubeLink) q.youtubeUrl = videoUrl.value;
+  if (item.value.mainArtist?.title) q.artist = item.value.mainArtist.title;
+  if (item.value.title) q.title = item.value.title;
+  return q;
+});
 const playAlong = ref(false);
 const fontSize = ref(1);
 const offsetFormatted = computed(() => {
@@ -759,8 +767,6 @@ onUnmounted(() => {
       <!-- Play-along entry — a prominent CTA at the top of the song content,
            kept out of the crowded footer toolbar. Shown only for playable
            songs when not already in play-along. -->
-      <!-- ponytail: play-along hidden via playAlongEnabled flag; entry CTA is the only way to
-           set playAlong=true, so the whole feature is unreachable. Logic left intact. -->
       <LxSection v-if="playAlongEnabled && playable && !playAlong" id="playAlongEnter">
         <div class="play-along-cta">
           <LxButton
@@ -771,6 +777,16 @@ onUnmounted(() => {
           />
           <p class="lx-description play-along-cta-hint">{{ $t('pages.playAlong.hint') }}</p>
         </div>
+      </LxSection>
+      <!-- Not playable (no video/timeline yet) — point people at the self-service
+           chord generator instead, prefilled with what we already know. -->
+      <LxSection v-if="playAlongEnabled && !playable" id="playAlongGenerateOwn">
+        <router-link
+          class="lx-secondary"
+          :to="{ name: 'chordGeneratorSubmit', query: generateOwnQuery }"
+        >
+          {{ $t('pages.playAlong.generateOwn') }}
+        </router-link>
       </LxSection>
       <LxSection v-if="playAlong" id="playAlong">
         <div class="play-along-exit">

--- a/src/views/SongView.vue
+++ b/src/views/SongView.vue
@@ -782,7 +782,7 @@ onUnmounted(() => {
            chord generator instead, prefilled with what we already know. -->
       <LxSection v-if="playAlongEnabled && !playable" id="playAlongGenerateOwn">
         <router-link
-          class="lx-secondary"
+          class="lx-secondary play-along-generate-own"
           :to="{ name: 'chordGeneratorSubmit', query: generateOwnQuery }"
         >
           {{ $t('pages.playAlong.generateOwn') }}


### PR DESCRIPTION
## Summary
- Resumes the play-along feature on the song page (`playAlongEnabled` flag flipped back on — it was fully built already, just hidden).
- Adds a new "Akordu ģenerators" self-service page: submit a YouTube URL (logged-in only) and get a play-along back; anyone (including logged-out visitors) can browse and play previously chordified songs, and rate them (`LxRating`, average shown publicly, list order always stays newest-first regardless of rating).
- No lyrics are ever requested/shown/stored on this page, no mp3 upload — YouTube URL only.
- No nav item — reachable by direct URL and via a small contextual link on the song page shown when a song isn't playable yet (prefills the submit form with the song's own artist/title/YouTube link).
- Depends on akordi/portal-api#17 for the backend contract (`/api/v2/chordgen-songs*`, `/api/v2/me/chordgen-songs*`).

## Test plan
- [x] `bun run lint`, `bun run test` — clean
- [x] Full local e2e stack built from this branch's source: complete Playwright suite (50 passed / 1 pre-existing unrelated skip), including the un-skipped play-along test and the full new chordgen suite
- [x] Manual walkthrough: entry-point link with prefill → submit → queue/ETA banner → poll → completion → play-along render → rate it → list view shows the new entry with its average rating → logged-out browsing of the list and an existing entry