### PR TITLE
Fix chordgen page rendering and rename to /chordgen

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -25,6 +25,7 @@ import '@dativa-lv/lx-ui/dist/styles/lx-inputs.css';
 import '@dativa-lv/lx-ui/dist/styles/lx-steps.css';
 import '@dativa-lv/lx-ui/dist/styles/lx-forms.css';
 import '@dativa-lv/lx-ui/dist/styles/lx-notifications.css';
+import '@dativa-lv/lx-ui/dist/styles/lx-info-boxes.css';
 import '@dativa-lv/lx-ui/dist/styles/lx-modals.css';
 import '@dativa-lv/lx-ui/dist/styles/lx-loaders.css';
 import '@dativa-lv/lx-ui/dist/styles/lx-lists.css';

--- a/src/router/routes.js
+++ b/src/router/routes.js
@@ -277,13 +277,16 @@ const routes = [
         component: () => import('@/views/SongView.vue'),
       },
       {
-        path: '/akordu-generators',
+        // Locale-neutral slug — this same route tree is deployed to every
+        // country site (lv/lt/ee/es), so it can't be a Latvian word like the
+        // old /akordu-generators was.
+        path: '/chordgen',
         name: 'chordGeneratorList',
         meta: { title: 'pages.chordGenerator.title', anonymous: true },
         component: () => import('@/views/ChordGeneratorList.vue'),
       },
       {
-        path: '/akordu-generators/jauns',
+        path: '/chordgen/new',
         name: 'chordGeneratorSubmit',
         meta: {
           title: 'pages.chordGenerator.submitTitle',
@@ -293,7 +296,7 @@ const routes = [
         component: () => import('@/views/ChordGeneratorSubmit.vue'),
       },
       {
-        path: '/akordu-generators/:id',
+        path: '/chordgen/:id',
         name: 'chordGeneratorView',
         meta: {
           anonymous: true,

--- a/src/views/ChordGeneratorSubmit.vue
+++ b/src/views/ChordGeneratorSubmit.vue
@@ -236,6 +236,7 @@ function actionClicked(actionName) {
 
 onMounted(async () => {
   viewStore.title = $t('pages.chordGenerator.submitTitle');
+  viewStore.description = '';
   viewStore.goBack = true;
   if (route.query.youtubeUrl) {
     item.value.youtubeUrl = String(route.query.youtubeUrl);
@@ -258,20 +259,26 @@ onUnmounted(() => {
 
 <template>
   <template v-if="!isAuthorized">
-    <LxInfoBox
-      :label="$t('pages.chordGenerator.loginRequired.title')"
-      :description="$t('pages.chordGenerator.loginRequired.message')"
-      variant="info"
-    />
-    <LxButton
-      kind="primary"
-      icon="next"
-      :label="$t('pages.chordGenerator.loginRequired.action')"
-      @click="authStore.login(route.fullPath)"
-    />
+    <LxRow>
+      <LxInfoBox
+        :label="$t('pages.chordGenerator.loginRequired.title')"
+        :description="$t('pages.chordGenerator.loginRequired.message')"
+        variant="info"
+      />
+    </LxRow>
+    <LxRow>
+      <LxButton
+        kind="primary"
+        icon="next"
+        :label="$t('pages.chordGenerator.loginRequired.action')"
+        @click="authStore.login(route.fullPath)"
+      />
+    </LxRow>
   </template>
   <template v-else>
-    <LxInfoBox v-if="queueMessage" :label="queueMessage" variant="info" />
+    <LxRow v-if="queueMessage">
+      <LxInfoBox :label="queueMessage" variant="info" />
+    </LxRow>
     <LxForm
       :action-definitions="formActions"
       @action-click="actionClicked"

--- a/src/views/ChordGeneratorView.vue
+++ b/src/views/ChordGeneratorView.vue
@@ -34,6 +34,7 @@ async function loadSong() {
     const resp = await chordgenSongService.findOne(route.params.id);
     song.value = resp.data;
     viewStore.title = `${song.value.artist} — ${song.value.title}`;
+    viewStore.description = '';
     viewStore.goBack = true;
   } catch (err) {
     notificationStore.pushError($t('pages.chordGenerator.errors.loadFailed'));


### PR DESCRIPTION
## Summary
Follow-up to #54 (merged), from a live report against the test environment plus review feedback:

- **Rendering bug**: the queue banner on `/chordgen/new` (formerly `/akordu-generators/jauns`) rendered as a giant unstyled icon swallowing the whole page. Root cause: `main.js` never imported `lx-info-boxes.css` — `LxInfoBox` was never used anywhere else in this app before this feature, so the missing import had never been hit. `admin-portal` already has this import; `portal` didn't. Also wrapped both `LxInfoBox` usages in `<LxRow>` to match the only other usage of this component in the codebase (admin-portal's `ChordGenerator.vue`) — needed regardless of the CSS fix, since `LxRow` supplies the layout context `LxInfoBox` expects.
- **Stale header text**: the submit/detail views never cleared `viewStore.description` (a persisted store, not route-scoped), so they kept showing the list view's leftover description.
- **Locale-neutral URL**: moved the route family from `/akordu-generators` (Latvian) to `/chordgen` (+ `/chordgen/new`, `/chordgen/:id`) — this same route tree is deployed to every country site (lv/lt/ee/es).

## Test plan
- [x] `bun run lint`, `bun run test` clean
- [x] Rebuilt the local e2e stack from this branch, full Playwright suite: 50 passed, 1 pre-existing unrelated skip
- [x] Manually verified via a real browser session against the rebuilt stack: submit page renders correctly (no more giant icon), queue banner shows real depth/ETA, submit returns 202 (paired with portal-api#18)