### PR TITLE
Improve chord generator UX: live queue status and synced chord diagrams

### DIFF
--- a/src/components/ChordPlayer.vue
+++ b/src/components/ChordPlayer.vue
@@ -10,7 +10,9 @@
  */
 import { computed, onBeforeUnmount, ref, shallowRef, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
+import { LxContentSwitcher } from '@dativa-lv/lx-ui';
 
+import ChordSvg from '@/components/ChordSvg.vue';
 import { activeSegmentIndex, youtubeId } from '@/utils/chordSync';
 
 const { t: $t } = useI18n();
@@ -19,7 +21,14 @@ const props = defineProps({
   videoUrl: { type: String, default: '' },
   segments: { type: Array, default: () => [] },
   duration: { type: Number, default: 0 },
+  // Opt-in side panel with fingering diagrams for every chord in the song,
+  // highlighting the one under the playhead. Off by default so existing
+  // usages (SongView play-along renders its own diagram grid) are unchanged.
+  showDiagrams: { type: Boolean, default: false },
+  instrument: { type: String, default: 'guitar' },
 });
+
+const emit = defineEmits(['update:instrument']);
 
 // Fixed-playhead scroller. The playhead stays put and the chord strip scrolls
 // continuously under it based on playback time, so nothing jumps when the chord
@@ -38,6 +47,28 @@ let tick = null;
 
 const videoId = computed(() => youtubeId(props.videoUrl));
 const activeIndex = computed(() => activeSegmentIndex(props.segments, currentTime.value));
+
+// Diagram panel data: every distinct chord of the song, in order of first
+// appearance, plus the label of the chord currently under the playhead.
+const uniqueChords = computed(() => {
+  const seen = new Set();
+  const out = [];
+  props.segments.forEach((seg) => {
+    if (seg.label && !seen.has(seg.label)) {
+      seen.add(seg.label);
+      out.push(seg.label);
+    }
+  });
+  return out;
+});
+
+const activeChord = computed(() => props.segments[activeIndex.value]?.label ?? null);
+
+const instrumentOptions = computed(() => [
+  { id: 'guitar', name: $t('pages.chordsLibrary.showGuitarChords.label') },
+  { id: 'ukulele', name: $t('pages.chordsLibrary.showUkuleleChords.label') },
+  { id: 'baritone-ukulele', name: $t('pages.chordsLibrary.showBaritoneUkuleleChords.label') },
+]);
 
 // Start of the visible time viewport. Clamped at 0 so the intro doesn't scroll
 // in from empty space before playback; once past the lead-in the viewport
@@ -193,37 +224,65 @@ onBeforeUnmount(() => {
 </script>
 
 <template>
-  <div class="chord-player">
-    <div class="chord-player-stage">
-      <div ref="mount" class="chord-player-frame"></div>
+  <div class="chord-player" :class="{ 'has-diagrams': showDiagrams && uniqueChords.length }">
+    <div class="chord-player-main">
+      <div class="chord-player-stage">
+        <div ref="mount" class="chord-player-frame"></div>
+      </div>
+
+      <!-- Scrolling chord track: the chords overlapping the visible time span are
+           laid out proportionally and scroll left under a fixed playhead as the
+           song plays, so the current chord sits at the playhead and the upcoming
+           progression is always visible ahead of it. -->
+      <div class="chord-player-track">
+        <!-- Rendered as role=button divs (not <button>) so the global LX UI
+             button sizing doesn't clamp the proportional width to a min square.
+             The visible text is the label only, so the accessible name matches
+             the chord exactly. -->
+        <div
+          v-for="item in visibleSegments"
+          :key="item.index"
+          class="chord-block"
+          role="button"
+          tabindex="0"
+          :class="{ 'is-active': item.index === activeIndex, 'is-past': item.index < activeIndex }"
+          :style="blockStyle(item.seg)"
+          :title="`${item.seg.label} · ${fmt(item.seg.end - item.seg.start)}`"
+          @click="seek(item.seg)"
+          @keydown.enter.prevent="seek(item.seg)"
+          @keydown.space.prevent="seek(item.seg)"
+        >
+          <span class="chord-block-label">{{ item.seg.label }}</span>
+        </div>
+        <div class="chord-player-playhead" :style="playheadStyle"></div>
+      </div>
     </div>
 
-    <!-- Scrolling chord track: the chords overlapping the visible time span are
-         laid out proportionally and scroll left under a fixed playhead as the
-         song plays, so the current chord sits at the playhead and the upcoming
-         progression is always visible ahead of it. -->
-    <div class="chord-player-track">
-      <!-- Rendered as role=button divs (not <button>) so the global LX UI
-           button sizing doesn't clamp the proportional width to a min square.
-           The visible text is the label only, so the accessible name matches
-           the chord exactly. -->
-      <div
-        v-for="item in visibleSegments"
-        :key="item.index"
-        class="chord-block"
-        role="button"
-        tabindex="0"
-        :class="{ 'is-active': item.index === activeIndex, 'is-past': item.index < activeIndex }"
-        :style="blockStyle(item.seg)"
-        :title="`${item.seg.label} · ${fmt(item.seg.end - item.seg.start)}`"
-        @click="seek(item.seg)"
-        @keydown.enter.prevent="seek(item.seg)"
-        @keydown.space.prevent="seek(item.seg)"
-      >
-        <span class="chord-block-label">{{ item.seg.label }}</span>
+    <!-- Fingering panel: one diagram per distinct chord in the song; the chord
+         under the playhead is highlighted in sync with the timeline. Sits to
+         the right of the video on wide screens, below it on narrow ones. -->
+    <aside
+      v-if="showDiagrams && uniqueChords.length"
+      class="chord-player-diagrams"
+      :aria-label="$t('pages.chordsLibrary.instrument')"
+    >
+      <LxContentSwitcher
+        id="chordPlayerInstrumentSwitcher"
+        :items="instrumentOptions"
+        :model-value="instrument"
+        @update:model-value="(value) => emit('update:instrument', value)"
+      />
+      <div class="chord-diagram-grid">
+        <div
+          v-for="chord in uniqueChords"
+          :key="chord"
+          class="chord-diagram"
+          :class="{ 'is-active': chord === activeChord }"
+        >
+          <ChordSvg :chord="chord" :instrument="instrument" />
+        </div>
       </div>
-      <div class="chord-player-playhead" :style="playheadStyle"></div>
-    </div>
+    </aside>
   </div>
 </template>
 
@@ -233,6 +292,48 @@ onBeforeUnmount(() => {
   flex-direction: column;
   gap: 1rem;
   max-width: 100%;
+}
+.chord-player-main {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  min-width: 0;
+  flex: 1 1 auto;
+}
+
+/* Diagram side panel ------------------------------------------------------ */
+.chord-player-diagrams {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  min-width: 0;
+}
+.chord-diagram-grid {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-start;
+  align-content: flex-start;
+  gap: 0.25rem;
+}
+.chord-diagram {
+  border: 2px solid transparent;
+  border-radius: 8px;
+  transition: border-color 0.15s ease, background-color 0.15s ease;
+}
+.chord-diagram.is-active {
+  border-color: var(--color-brand, #18bc9c);
+  background: var(--color-region-2, #eee);
+}
+
+/* Side-by-side once there is room for the video and a diagram column. */
+@media (min-width: 64rem) {
+  .chord-player.has-diagrams {
+    flex-direction: row;
+    align-items: flex-start;
+  }
+  .chord-player.has-diagrams .chord-player-diagrams {
+    flex: 0 0 18rem;
+  }
 }
 .chord-player-stage {
   position: relative;

--- a/src/locales/ee.json
+++ b/src/locales/ee.json
@@ -243,6 +243,7 @@
             },
             "status": {
                 "pending": "Ootab järjekorras...",
+                "position": "Sinu ees järjekorras: {count}",
                 "running": "Akordide genereerimine käib...",
                 "exists": "See laul on juba saadaval",
                 "rateLimited": "Esituste limiit on täis. Palun proovi hiljem uuesti.",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -243,6 +243,7 @@
             },
             "status": {
                 "pending": "Esperando en la cola...",
+                "position": "Por delante en la cola: {count}",
                 "running": "Generando los acordes...",
                 "exists": "Esta canción ya está disponible",
                 "rateLimited": "Se alcanzó el límite de envíos. Inténtalo más tarde.",

--- a/src/locales/lt.json
+++ b/src/locales/lt.json
@@ -243,6 +243,7 @@
             },
             "status": {
                 "pending": "Laukiama eilėje...",
+                "position": "Prieš tave eilėje: {count}",
                 "running": "Generuojami akordai...",
                 "exists": "Ši daina jau yra pridėta",
                 "rateLimited": "Pasiektas pateikimų limitas. Bandyk vėliau.",

--- a/src/locales/lv.json
+++ b/src/locales/lv.json
@@ -243,6 +243,7 @@
             },
             "status": {
                 "pending": "Rindā gaida apstrādi...",
+                "position": "Priekšā rindā: {count}",
                 "running": "Tiek ģenerēti akordi...",
                 "exists": "Šī dziesma jau ir pieejama",
                 "rateLimited": "Sasniegts iesniegumu limits. Lūdzu, mēģini vēlāk.",

--- a/src/views/ChordGeneratorSubmit.vue
+++ b/src/views/ChordGeneratorSubmit.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { LxButton, LxForm, LxInfoBox, LxRow, LxTextInput } from '@dativa-lv/lx-ui';
+import { LxButton, LxForm, LxInfoBox, LxLoader, LxRow, LxTextInput } from '@dativa-lv/lx-ui';
 import { computed, onMounted, onUnmounted, ref } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { useRoute, useRouter } from 'vue-router';
@@ -80,20 +80,33 @@ const queueMessage = computed(() => {
   return `${depth} · ${$t('pages.chordGenerator.queue.eta', { eta: wait })}`;
 });
 
-const submittingMessage = computed(() => {
-  if (!jobStatus.value) {
-    return '';
-  }
-  if (jobStatus.value.status === 'running') {
+// Live progress panel shown instead of the queue snapshot while a job is in
+// flight — label is the job state, description carries queue position + ETA.
+const progressLabel = computed(() => {
+  if (jobStatus.value?.status === 'running') {
     return $t('pages.chordGenerator.status.running');
   }
-  if (jobStatus.value.status === 'pending') {
-    if (jobStatus.value.queueAhead != null) {
-      return `${$t('pages.chordGenerator.status.pending')} (${jobStatus.value.queueAhead})`;
-    }
-    return $t('pages.chordGenerator.status.pending');
+  return $t('pages.chordGenerator.status.pending');
+});
+
+const progressDescription = computed(() => {
+  if (jobStatus.value?.status !== 'pending') {
+    return '';
   }
-  return '';
+  const parts = [];
+  const ahead = jobStatus.value.queueAhead;
+  if (ahead != null) {
+    parts.push($t('pages.chordGenerator.status.position', { count: ahead }));
+  }
+  // Prefer an ETA scoped to this job's queue position; fall back to the
+  // whole-queue estimate when the position is unknown.
+  const avg = queue.value?.avgProcessingSeconds;
+  const wait = ahead != null && avg ? (ahead + 1) * avg : queue.value?.estimatedWaitSeconds;
+  const eta = formatWait(wait);
+  if (eta) {
+    parts.push($t('pages.chordGenerator.queue.eta', { eta }));
+  }
+  return parts.join(' · ');
 });
 
 async function loadQueue() {
@@ -184,6 +197,10 @@ async function pollJob(jobId) {
     notificationStore.pushError($t('pages.chordGenerator.status.error'));
     return;
   }
+  // Keep the queue snapshot live too — it feeds the ETA in the progress panel
+  // and goes back to being the visible banner once the job finishes. Fire and
+  // forget: loadQueue swallows its own failures.
+  loadQueue();
   try {
     const resp = await chordgenSongService.getMyJob(jobId);
     const { data } = resp;
@@ -304,7 +321,13 @@ onUnmounted(() => {
     </LxRow>
   </template>
   <template v-else>
-    <LxRow v-if="queueMessage">
+    <!-- One merged status panel: a live progress view while a job is in
+         flight, otherwise the current queue snapshot. Never both, and the
+         snapshot is refreshed on every poll so it can't go stale. -->
+    <LxRow v-if="jobStatus">
+      <LxLoader loading variant="bar" :label="progressLabel" :description="progressDescription" />
+    </LxRow>
+    <LxRow v-else-if="queueMessage">
       <LxInfoBox :label="queueMessage" variant="info" />
     </LxRow>
     <LxForm
@@ -327,8 +350,5 @@ onUnmounted(() => {
         />
       </LxRow>
     </LxForm>
-    <LxRow v-if="submittingMessage">
-      <LxInfoBox :label="submittingMessage" variant="info" />
-    </LxRow>
   </template>
 </template>

--- a/src/views/ChordGeneratorView.vue
+++ b/src/views/ChordGeneratorView.vue
@@ -6,8 +6,10 @@ import { useRoute } from 'vue-router';
 
 import ChordPlayer from '@/components/ChordPlayer.vue';
 import chordgenSongService from '@/services/chordgenSongService';
+import useAccountPreferencesStore from '@/stores/useAccountPreferencesStore';
 import useAuthStore from '@/stores/useAuthStore';
 import useNotifyStore from '@/stores/useNotifyStore';
+import useSettingsStore from '@/stores/useSettingsStore';
 import useViewStore from '@/stores/useViewStore';
 
 const $t = useI18n().t;
@@ -15,6 +17,8 @@ const route = useRoute();
 const viewStore = useViewStore();
 const notificationStore = useNotifyStore();
 const authStore = useAuthStore();
+const settingsStore = useSettingsStore();
+const accountPreferencesStore = useAccountPreferencesStore();
 const isAuthorized = authStore.isAuthenticated();
 
 const loading = ref(true);
@@ -57,6 +61,21 @@ async function loadMyRating() {
   }
 }
 
+// Same behaviour as SongView/ChordsLibraryView: the choice applies immediately
+// for everyone (device-local setting) and is also saved to the account
+// preferences when signed in.
+async function selectInstrument(instrument) {
+  settingsStore.instrument = instrument;
+  if (!isAuthorized) {
+    return;
+  }
+  try {
+    await accountPreferencesStore.saveInstrument(instrument);
+  } catch (err) {
+    notificationStore.pushError($t('pages.userProfile.preferences.saveError'));
+  }
+}
+
 async function onRate(value) {
   const previous = myRating.value;
   myRating.value = value;
@@ -82,7 +101,14 @@ onMounted(async () => {
   <LxLoaderView :loading="loading">
     <!-- The page header (viewStore.title, set in loadSong) already shows the
          title — no need to repeat it here. -->
-    <ChordPlayer :video-url="song.youtubeUrl" :segments="song.segments" :duration="song.duration" />
+    <ChordPlayer
+      :video-url="song.youtubeUrl"
+      :segments="song.segments"
+      :duration="song.duration"
+      show-diagrams
+      :instrument="settingsStore.instrument"
+      @update:instrument="selectInstrument"
+    />
 
     <div style="display: flex; align-items: center; gap: 0.5rem; margin-top: 1rem">
       <LxRating :model-value="song.averageRating || 0" read-only kind="5stars" :focusable="false" />

--- a/tests/unit/chordGeneratorSubmit.test.js
+++ b/tests/unit/chordGeneratorSubmit.test.js
@@ -1,0 +1,141 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mount, flushPromises } from '@vue/test-utils';
+import { ref } from 'vue';
+
+const { submit, getMyJob, getQueue, pushError } = vi.hoisted(() => ({
+  submit: vi.fn(),
+  getMyJob: vi.fn(),
+  getQueue: vi.fn(),
+  pushError: vi.fn(),
+}));
+
+vi.mock('@dativa-lv/lx-ui', () => ({
+  LxButton: { name: 'LxButton', props: ['label'], template: '<button />' },
+  LxForm: {
+    name: 'LxForm',
+    props: ['actionDefinitions'],
+    emits: ['action-click'],
+    template: '<form><slot /></form>',
+  },
+  LxInfoBox: { name: 'LxInfoBox', props: ['label', 'variant'], template: '<div />' },
+  LxLoader: {
+    name: 'LxLoader',
+    props: ['loading', 'variant', 'label', 'description'],
+    template: '<div />',
+  },
+  LxRow: { name: 'LxRow', props: ['label'], template: '<div><slot /></div>' },
+  LxTextInput: {
+    name: 'LxTextInput',
+    props: ['modelValue'],
+    emits: ['update:modelValue', 'blur'],
+    template: '<input />',
+  },
+}));
+vi.mock('@vuelidate/core', () => ({
+  default: () =>
+    ref({ $validate: async () => true, youtubeUrl: { $error: false, $errors: [] } }),
+}));
+vi.mock('@vuelidate/validators', () => ({
+  createI18nMessage: () => (rule) => rule,
+  required: {},
+  url: {},
+}));
+vi.mock('@/services/chordgenSongService', () => ({
+  default: { submit, getMyJob, getQueue },
+}));
+vi.mock('vue-i18n', () => ({ useI18n: () => ({ t: (key) => key }) }));
+vi.mock('vue-router', () => ({
+  useRoute: () => ({ query: { youtubeUrl: 'https://youtu.be/abc123def45' }, fullPath: '/x' }),
+  useRouter: () => ({ push: vi.fn() }),
+}));
+vi.mock('@/stores/useViewStore', () => ({
+  default: () => ({ title: '', description: '', goBack: false }),
+}));
+vi.mock('@/stores/useNotifyStore', () => ({
+  default: () => ({ pushError, pushSuccess: vi.fn() }),
+}));
+vi.mock('@/stores/useAuthStore', () => ({
+  default: () => ({ isAuthenticated: () => true, login: vi.fn() }),
+}));
+
+import ChordGeneratorSubmit from '@/views/ChordGeneratorSubmit.vue';
+
+const queueSnapshot = (overrides = {}) => ({
+  data: {
+    pending: 0,
+    running: 0,
+    avgProcessingSeconds: 60,
+    estimatedWaitSeconds: 0,
+    ...overrides,
+  },
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.useFakeTimers();
+  // oEmbed title guess — irrelevant here, always fails silently.
+  vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('offline')));
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+});
+
+describe('ChordGeneratorSubmit live status panel', () => {
+  it('shows the queue snapshot before any submission', async () => {
+    getQueue.mockResolvedValue(queueSnapshot());
+    const wrapper = mount(ChordGeneratorSubmit);
+    await flushPromises();
+
+    expect(getQueue).toHaveBeenCalledTimes(1);
+    expect(wrapper.findComponent({ name: 'LxInfoBox' }).props('label')).toBe(
+      'pages.chordGenerator.queue.none'
+    );
+    expect(wrapper.findComponent({ name: 'LxLoader' }).exists()).toBe(false);
+  });
+
+  it('replaces the snapshot with a live progress panel and re-fetches the queue on every poll', async () => {
+    getQueue.mockResolvedValue(queueSnapshot({ pending: 2, running: 1 }));
+    submit.mockResolvedValue({ data: { status: 'pending', id: 'job-1' } });
+    getMyJob.mockResolvedValue({ data: { status: 'pending', queueAhead: 2 } });
+
+    const wrapper = mount(ChordGeneratorSubmit);
+    await flushPromises();
+    expect(getQueue).toHaveBeenCalledTimes(1);
+
+    wrapper.findComponent({ name: 'LxForm' }).vm.$emit('action-click', 'submit');
+    await flushPromises();
+
+    // Submitting kicked off an immediate poll, which also refreshed the queue.
+    expect(getMyJob).toHaveBeenCalledTimes(1);
+    expect(getQueue).toHaveBeenCalledTimes(2);
+
+    // The stale "queue is empty" info box is gone; the live panel is shown
+    // with the job's own position in the queue.
+    expect(wrapper.findComponent({ name: 'LxInfoBox' }).exists()).toBe(false);
+    const loader = wrapper.findComponent({ name: 'LxLoader' });
+    expect(loader.props('label')).toBe('pages.chordGenerator.status.pending');
+    expect(loader.props('description')).toContain('pages.chordGenerator.status.position');
+
+    // Every subsequent poll tick refreshes both the job and the queue.
+    await vi.advanceTimersByTimeAsync(3000);
+    expect(getMyJob).toHaveBeenCalledTimes(2);
+    expect(getQueue).toHaveBeenCalledTimes(3);
+  });
+
+  it('switches the panel to the running state as the job progresses', async () => {
+    getQueue.mockResolvedValue(queueSnapshot({ running: 1 }));
+    submit.mockResolvedValue({ data: { status: 'pending', id: 'job-1' } });
+    getMyJob.mockResolvedValue({ data: { status: 'running' } });
+
+    const wrapper = mount(ChordGeneratorSubmit);
+    await flushPromises();
+    wrapper.findComponent({ name: 'LxForm' }).vm.$emit('action-click', 'submit');
+    await flushPromises();
+
+    const loader = wrapper.findComponent({ name: 'LxLoader' });
+    expect(loader.props('label')).toBe('pages.chordGenerator.status.running');
+    expect(loader.props('description')).toBe('');
+  });
+});

--- a/tests/unit/chordPlayer.test.js
+++ b/tests/unit/chordPlayer.test.js
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi } from 'vitest';
+import { mount } from '@vue/test-utils';
+
+vi.mock('@dativa-lv/lx-ui', () => ({
+  LxContentSwitcher: {
+    name: 'LxContentSwitcher',
+    props: ['items', 'modelValue'],
+    emits: ['update:modelValue'],
+    template: '<div />',
+  },
+}));
+vi.mock('@/components/ChordSvg.vue', () => ({
+  default: {
+    name: 'ChordSvg',
+    props: ['chord', 'instrument'],
+    template: '<div />',
+  },
+}));
+vi.mock('vue-i18n', () => ({ useI18n: () => ({ t: (key) => key }) }));
+
+import ChordPlayer from '@/components/ChordPlayer.vue';
+
+const segments = [
+  { start: 0, end: 2, label: 'Am' },
+  { start: 2, end: 4, label: 'C' },
+  { start: 4, end: 6, label: 'Am' },
+  { start: 6, end: 8, label: 'G' },
+];
+
+const mountPlayer = (props = {}) =>
+  mount(ChordPlayer, {
+    props: { videoUrl: 'https://youtu.be/abc123def45', segments, duration: 8, ...props },
+  });
+
+describe('ChordPlayer chord diagram panel', () => {
+  it('is hidden by default so existing usages are unchanged', () => {
+    const wrapper = mountPlayer();
+    expect(wrapper.find('.chord-player-diagrams').exists()).toBe(false);
+    expect(wrapper.findComponent({ name: 'LxContentSwitcher' }).exists()).toBe(false);
+  });
+
+  it('renders one diagram per distinct chord, in order of first appearance', () => {
+    const wrapper = mountPlayer({ showDiagrams: true });
+    const diagrams = wrapper.findAllComponents({ name: 'ChordSvg' });
+    expect(diagrams.map((d) => d.props('chord'))).toEqual(['Am', 'C', 'G']);
+  });
+
+  it('highlights the chord under the playhead', () => {
+    const wrapper = mountPlayer({ showDiagrams: true });
+    // Playback starts at 0s, which falls in the first segment (Am).
+    const active = wrapper.findAll('.chord-diagram.is-active');
+    expect(active).toHaveLength(1);
+    expect(active[0].findComponent({ name: 'ChordSvg' }).props('chord')).toBe('Am');
+  });
+
+  it('passes the instrument to diagrams and re-emits switcher changes', async () => {
+    const wrapper = mountPlayer({ showDiagrams: true, instrument: 'ukulele' });
+    const diagrams = wrapper.findAllComponents({ name: 'ChordSvg' });
+    expect(diagrams.every((d) => d.props('instrument') === 'ukulele')).toBe(true);
+
+    const switcher = wrapper.findComponent({ name: 'LxContentSwitcher' });
+    expect(switcher.props('modelValue')).toBe('ukulele');
+    switcher.vm.$emit('update:modelValue', 'guitar');
+    expect(wrapper.emitted('update:instrument')).toEqual([['guitar']]);
+  });
+
+  it('hides the panel when segments carry no labels', () => {
+    const wrapper = mountPlayer({
+      showDiagrams: true,
+      segments: [{ start: 0, end: 2, label: '' }],
+    });
+    expect(wrapper.find('.chord-player-diagrams').exists()).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes the stale queue banner on the chord generator submit view and adds instrument-aware chord fingering diagrams next to the play-along timeline on the generated-song view.

### Submit view — live merged status panel

The queue snapshot was fetched once on mount and never again, so after submitting a song the banner kept showing "Rinda pašlaik ir tukša" while the submitter's own job was sitting in that queue. The two separate info boxes (queue banner on top, job status below the form) are now one panel:

- **Idle:** the existing queue snapshot (`LxInfoBox`) — depth + estimated wait.
- **Job in flight:** an `LxLoader` progress bar showing the job state, the number of jobs ahead of yours (new `status.position` locale key in lv/ee/es/lt), and an ETA scoped to your queue position (`(ahead + 1) × avgProcessingSeconds`, falling back to the whole-queue estimate).
- The queue snapshot is re-fetched on every 3s poll tick, so it feeds a live ETA during the job and is fresh again the moment the panel returns to the idle state.

### Generated-song view — synced chord tabs with instrument selection

`ChordPlayer` gains an opt-in (`show-diagrams`) side panel, off by default so SongView's play-along is untouched:

- One `ChordSvg` fingering diagram per distinct chord in the song, in order of first appearance.
- The diagram of the chord under the playhead is highlighted in sync with the scrolling timeline.
- `LxContentSwitcher` for guitar / ukulele / baritone-ukulele, reusing the existing `pages.chordsLibrary.*` labels.
- Responsive: diagrams sit to the right of the video on wide screens (≥64rem) and stack below it on mobile.

`ChordGeneratorView` enables the panel and persists the instrument choice exactly like SongView/ChordsLibraryView: applied immediately via `settingsStore`, saved to account preferences when signed in.

## Testing

- `bun run lint`, `bun run test` (45 tests, 8 new), and `bun run build` all pass.
- New unit tests cover: diagram panel hidden by default, unique-chord ordering, playhead-synced highlight, instrument prop/emit wiring, the merged status panel replacing the queue banner after submit, queue re-fetch on every poll tick, and the pending → running label transition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RnF4w9DcbKw9WaqEYoDMED

---
_Generated by [Claude Code](https://claude.ai/code/session_01RnF4w9DcbKw9WaqEYoDMED)_