### PR TITLE
Simplify chord diagram panel and hide empty rating summary

### DIFF
--- a/src/components/ChordPlayer.vue
+++ b/src/components/ChordPlayer.vue
@@ -49,7 +49,9 @@ const videoId = computed(() => youtubeId(props.videoUrl));
 const activeIndex = computed(() => activeSegmentIndex(props.segments, currentTime.value));
 
 // Diagram panel data: every distinct chord of the song, in order of first
-// appearance, plus the label of the chord currently under the playhead.
+// appearance. Deliberately NOT synced to the playhead — the timeline already
+// highlights the current chord, and a second moving highlight reads as
+// fragmented; the panel is a static fingering reference.
 const uniqueChords = computed(() => {
   const seen = new Set();
   const out = [];
@@ -61,8 +63,6 @@ const uniqueChords = computed(() => {
   });
   return out;
 });
-
-const activeChord = computed(() => props.segments[activeIndex.value]?.label ?? null);
 
 const instrumentOptions = computed(() => [
   { id: 'guitar', name: $t('pages.chordsLibrary.showGuitarChords.label') },
@@ -258,9 +258,9 @@ onBeforeUnmount(() => {
       </div>
     </div>
 
-    <!-- Fingering panel: one diagram per distinct chord in the song; the chord
-         under the playhead is highlighted in sync with the timeline. Sits to
-         the right of the video on wide screens, below it on narrow ones. -->
+    <!-- Fingering panel: a static reference with one diagram per distinct
+         chord in the song. Sits to the right of the video on wide screens,
+         below it on narrow ones. -->
     <aside
       v-if="showDiagrams && uniqueChords.length"
       class="chord-player-diagrams"
@@ -273,14 +273,12 @@ onBeforeUnmount(() => {
         @update:model-value="(value) => emit('update:instrument', value)"
       />
       <div class="chord-diagram-grid">
-        <div
+        <ChordSvg
           v-for="chord in uniqueChords"
           :key="chord"
-          class="chord-diagram"
-          :class="{ 'is-active': chord === activeChord }"
-        >
-          <ChordSvg :chord="chord" :instrument="instrument" />
-        </div>
+          :chord="chord"
+          :instrument="instrument"
+        />
       </div>
     </aside>
   </div>
@@ -314,15 +312,6 @@ onBeforeUnmount(() => {
   align-items: flex-start;
   align-content: flex-start;
   gap: 0.25rem;
-}
-.chord-diagram {
-  border: 2px solid transparent;
-  border-radius: 8px;
-  transition: border-color 0.15s ease, background-color 0.15s ease;
-}
-.chord-diagram.is-active {
-  border-color: var(--color-brand, #18bc9c);
-  background: var(--color-region-2, #eee);
 }
 
 /* Side-by-side once there is room for the video and a diagram column. */

--- a/src/views/ChordGeneratorSubmit.vue
+++ b/src/views/ChordGeneratorSubmit.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { LxButton, LxForm, LxInfoBox, LxLoader, LxRow, LxTextInput } from '@dativa-lv/lx-ui';
+import { LxButton, LxForm, LxInfoBox, LxRow, LxTextInput } from '@dativa-lv/lx-ui';
 import { computed, onMounted, onUnmounted, ref } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { useRoute, useRouter } from 'vue-router';
@@ -80,8 +80,10 @@ const queueMessage = computed(() => {
   return `${depth} · ${$t('pages.chordGenerator.queue.eta', { eta: wait })}`;
 });
 
-// Live progress panel shown instead of the queue snapshot while a job is in
-// flight — label is the job state, description carries queue position + ETA.
+// While a job is in flight the same info box switches to live job status —
+// label is the job state, description carries queue position + ETA. One
+// persistent component for both states, so nothing visually swaps out on
+// submit (the busy spinner on the submit button already signals activity).
 const progressLabel = computed(() => {
   if (jobStatus.value?.status === 'running') {
     return $t('pages.chordGenerator.status.running');
@@ -321,11 +323,11 @@ onUnmounted(() => {
     </LxRow>
   </template>
   <template v-else>
-    <!-- One merged status panel: a live progress view while a job is in
-         flight, otherwise the current queue snapshot. Never both, and the
+    <!-- One persistent status box: the current queue snapshot while idle,
+         live job status (position + ETA) while a job is in flight. The
          snapshot is refreshed on every poll so it can't go stale. -->
     <LxRow v-if="jobStatus">
-      <LxLoader loading variant="bar" :label="progressLabel" :description="progressDescription" />
+      <LxInfoBox :label="progressLabel" :description="progressDescription" variant="info" />
     </LxRow>
     <LxRow v-else-if="queueMessage">
       <LxInfoBox :label="queueMessage" variant="info" />

--- a/src/views/ChordGeneratorView.vue
+++ b/src/views/ChordGeneratorView.vue
@@ -25,12 +25,12 @@ const loading = ref(true);
 const song = ref({});
 const myRating = ref(null);
 
-const ratingSummary = computed(() => {
-  if (!song.value.ratingsCount) {
-    return $t('pages.chordGenerator.rating.none');
-  }
-  return `${(song.value.averageRating || 0).toFixed(1)} (${song.value.ratingsCount})`;
-});
+// Only rendered when ratings exist — a "no ratings yet" line next to the
+// rate-this-song control reads oddly, so the average row is simply hidden
+// until the first rating lands.
+const ratingSummary = computed(
+  () => `${(song.value.averageRating || 0).toFixed(1)} (${song.value.ratingsCount})`
+);
 
 // Artist is optional — don't show a dangling "— Title" when it's blank.
 const displayTitle = computed(() =>
@@ -110,7 +110,10 @@ onMounted(async () => {
       @update:instrument="selectInstrument"
     />
 
-    <div style="display: flex; align-items: center; gap: 0.5rem; margin-top: 1rem">
+    <div
+      v-if="song.ratingsCount"
+      style="display: flex; align-items: center; gap: 0.5rem; margin-top: 1rem"
+    >
       <LxRating :model-value="song.averageRating || 0" read-only kind="5stars" :focusable="false" />
       <span class="lx-secondary">{{ ratingSummary }}</span>
     </div>

--- a/tests/unit/chordGeneratorSubmit.test.js
+++ b/tests/unit/chordGeneratorSubmit.test.js
@@ -17,10 +17,9 @@ vi.mock('@dativa-lv/lx-ui', () => ({
     emits: ['action-click'],
     template: '<form><slot /></form>',
   },
-  LxInfoBox: { name: 'LxInfoBox', props: ['label', 'variant'], template: '<div />' },
-  LxLoader: {
-    name: 'LxLoader',
-    props: ['loading', 'variant', 'label', 'description'],
+  LxInfoBox: {
+    name: 'LxInfoBox',
+    props: ['label', 'description', 'variant'],
     template: '<div />',
   },
   LxRow: { name: 'LxRow', props: ['label'], template: '<div><slot /></div>' },
@@ -82,17 +81,16 @@ afterEach(() => {
   vi.unstubAllGlobals();
 });
 
-describe('ChordGeneratorSubmit live status panel', () => {
+describe('ChordGeneratorSubmit persistent status box', () => {
   it('shows the queue snapshot before any submission', async () => {
     getQueue.mockResolvedValue(queueSnapshot());
     const wrapper = mount(ChordGeneratorSubmit);
     await flushPromises();
 
     expect(getQueue).toHaveBeenCalledTimes(1);
-    expect(wrapper.findComponent({ name: 'LxInfoBox' }).props('label')).toBe(
-      'pages.chordGenerator.queue.none'
-    );
-    expect(wrapper.findComponent({ name: 'LxLoader' }).exists()).toBe(false);
+    const box = wrapper.findComponent({ name: 'LxInfoBox' });
+    expect(box.props('label')).toBe('pages.chordGenerator.queue.none');
+    expect(box.props('description')).toBeFalsy();
   });
 
   it('replaces the snapshot with a live progress panel and re-fetches the queue on every poll', async () => {
@@ -111,12 +109,11 @@ describe('ChordGeneratorSubmit live status panel', () => {
     expect(getMyJob).toHaveBeenCalledTimes(1);
     expect(getQueue).toHaveBeenCalledTimes(2);
 
-    // The stale "queue is empty" info box is gone; the live panel is shown
-    // with the job's own position in the queue.
-    expect(wrapper.findComponent({ name: 'LxInfoBox' }).exists()).toBe(false);
-    const loader = wrapper.findComponent({ name: 'LxLoader' });
-    expect(loader.props('label')).toBe('pages.chordGenerator.status.pending');
-    expect(loader.props('description')).toContain('pages.chordGenerator.status.position');
+    // The same info box persists but now shows live job status with the
+    // job's own position in the queue instead of the stale snapshot.
+    const box = wrapper.findComponent({ name: 'LxInfoBox' });
+    expect(box.props('label')).toBe('pages.chordGenerator.status.pending');
+    expect(box.props('description')).toContain('pages.chordGenerator.status.position');
 
     // Every subsequent poll tick refreshes both the job and the queue.
     await vi.advanceTimersByTimeAsync(3000);
@@ -134,8 +131,8 @@ describe('ChordGeneratorSubmit live status panel', () => {
     wrapper.findComponent({ name: 'LxForm' }).vm.$emit('action-click', 'submit');
     await flushPromises();
 
-    const loader = wrapper.findComponent({ name: 'LxLoader' });
-    expect(loader.props('label')).toBe('pages.chordGenerator.status.running');
-    expect(loader.props('description')).toBe('');
+    const box = wrapper.findComponent({ name: 'LxInfoBox' });
+    expect(box.props('label')).toBe('pages.chordGenerator.status.running');
+    expect(box.props('description')).toBe('');
   });
 });

--- a/tests/unit/chordPlayer.test.js
+++ b/tests/unit/chordPlayer.test.js
@@ -45,12 +45,11 @@ describe('ChordPlayer chord diagram panel', () => {
     expect(diagrams.map((d) => d.props('chord'))).toEqual(['Am', 'C', 'G']);
   });
 
-  it('highlights the chord under the playhead', () => {
+  it('does not highlight diagrams in sync with playback (static reference only)', () => {
     const wrapper = mountPlayer({ showDiagrams: true });
-    // Playback starts at 0s, which falls in the first segment (Am).
-    const active = wrapper.findAll('.chord-diagram.is-active');
-    expect(active).toHaveLength(1);
-    expect(active[0].findComponent({ name: 'ChordSvg' }).props('chord')).toBe('Am');
+    // The timeline is the only place tracking the current chord — the diagram
+    // panel stays static so there aren't two competing highlights.
+    expect(wrapper.find('.chord-player-diagrams .is-active').exists()).toBe(false);
   });
 
   it('passes the instrument to diagrams and re-emits switcher changes', async () => {


### PR DESCRIPTION
## Summary

Follow-up UX polish on #57 based on feedback from testing:

- **Chord diagram panel is now a static reference.** The playhead-synced highlight is removed — the timeline already highlights the current chord, and a second moving highlight in the diagram panel read as fragmented. The instrument switcher and responsive layout are unchanged.
- **The average-rating row is hidden until the song has at least one rating.** Showing "Vēl nav vērtējumu" right next to the rate-this-song control read oddly; now only the "Tavs vērtējums" control shows on an unrated song, and the average row appears once the first rating lands.

## Testing

- `bun run lint`, `bun run test` (45 tests — the diagram test now asserts the panel stays un-highlighted during playback), and `bun run build` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RnF4w9DcbKw9WaqEYoDMED

---
_Generated by [Claude Code](https://claude.ai/code/session_01RnF4w9DcbKw9WaqEYoDMED)_