### PR TITLE
Add practice controls, chord diagram fallbacks, and submission allowance display

### DIFF
--- a/src/components/ChordPlayer.vue
+++ b/src/components/ChordPlayer.vue
@@ -10,10 +10,11 @@
  */
 import { computed, onBeforeUnmount, ref, shallowRef, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
-import { LxContentSwitcher } from '@dativa-lv/lx-ui';
+import { LxButton, LxContentSwitcher } from '@dativa-lv/lx-ui';
 
 import ChordSvg from '@/components/ChordSvg.vue';
 import { activeSegmentIndex, youtubeId } from '@/utils/chordSync';
+import { capoForOffset, transposeChord } from '@/utils/chordName';
 
 const { t: $t } = useI18n();
 
@@ -26,9 +27,21 @@ const props = defineProps({
   // usages (SongView play-along renders its own diagram grid) are unchanged.
   showDiagrams: { type: Boolean, default: false },
   instrument: { type: String, default: 'guitar' },
+  // Opt-in transpose control (±semitones with a capo hint). Off by default:
+  // SongView's play-along already has a body-level transpose, and a second
+  // transposer there would fight it.
+  hasTranspose: { type: Boolean, default: false },
 });
 
 const emit = defineEmits(['update:instrument']);
+
+// Practice speeds the YouTube player reliably supports on any video.
+const PLAYBACK_RATES = [0.5, 0.75, 1];
+// Display transpose bounds: every distinct pitch is reachable within ±11.
+const TRANSPOSE_MIN = -11;
+const TRANSPOSE_MAX = 11;
+// Capo suggestions above this fret are impractical on a real neck.
+const CAPO_MAX_FRET = 7;
 
 // Fixed-playhead scroller. The playhead stays put and the chord strip scrolls
 // continuously under it based on playback time, so nothing jumps when the chord
@@ -48,6 +61,62 @@ let tick = null;
 const videoId = computed(() => youtubeId(props.videoUrl));
 const activeIndex = computed(() => activeSegmentIndex(props.segments, currentTime.value));
 
+// Playback speed — applied to the YouTube player, remembered across song
+// switches within the component's lifetime.
+const playbackRate = ref(1);
+
+// Display transpose in semitones. Affects labels only (timeline + diagrams);
+// timing and playback are untouched.
+const transpose = ref(0);
+
+const speedOptions = PLAYBACK_RATES.map((rate) => ({ id: String(rate), name: `${rate}×` }));
+
+const speedId = computed({
+  get: () => String(playbackRate.value),
+  set: (value) => {
+    playbackRate.value = Number(value);
+  },
+});
+
+function applyPlaybackRate() {
+  if (player && typeof player.setPlaybackRate === 'function') {
+    player.setPlaybackRate(playbackRate.value);
+  }
+}
+
+function bumpTranspose(step) {
+  transpose.value = Math.min(TRANSPOSE_MAX, Math.max(TRANSPOSE_MIN, transpose.value + step));
+}
+
+const transposeLabel = computed(() =>
+  transpose.value > 0 ? `+${transpose.value}` : String(transpose.value)
+);
+
+// "Play these easier shapes with a capo and it still sounds like the record."
+// Only meaningful when transposed, and only for frets a real capo reaches.
+const capoHint = computed(() => {
+  if (!props.hasTranspose || transpose.value === 0) {
+    return '';
+  }
+  const fret = capoForOffset(transpose.value);
+  if (fret < 1 || fret > CAPO_MAX_FRET) {
+    return '';
+  }
+  return $t('pages.playAlong.capoHint', { fret });
+});
+
+// Segments as displayed: original timing, labels transposed when the control
+// is active. Everything downstream (timeline, diagrams) reads these.
+const displaySegments = computed(() => {
+  if (!props.hasTranspose || transpose.value === 0) {
+    return props.segments;
+  }
+  return props.segments.map((seg) => ({
+    ...seg,
+    label: transposeChord(seg.label, transpose.value),
+  }));
+});
+
 // Diagram panel data: every distinct chord of the song, in order of first
 // appearance. Deliberately NOT synced to the playhead — the timeline already
 // highlights the current chord, and a second moving highlight reads as
@@ -55,7 +124,7 @@ const activeIndex = computed(() => activeSegmentIndex(props.segments, currentTim
 const uniqueChords = computed(() => {
   const seen = new Set();
   const out = [];
-  props.segments.forEach((seg) => {
+  displaySegments.value.forEach((seg) => {
     if (seg.label && !seen.has(seg.label)) {
       seen.add(seg.label);
       out.push(seg.label);
@@ -79,9 +148,10 @@ const viewStart = computed(() => Math.max(0, currentTime.value - LEAD_FRACTION *
 const visibleSegments = computed(() => {
   const start = viewStart.value;
   const end = start + VIEW_SPAN_SEC;
+  const segments = displaySegments.value;
   const out = [];
-  for (let i = 0; i < props.segments.length; i += 1) {
-    const seg = props.segments[i];
+  for (let i = 0; i < segments.length; i += 1) {
+    const seg = segments[i];
     if (seg.end >= start && seg.start <= end) {
       out.push({ seg, index: i });
     }
@@ -178,6 +248,9 @@ async function build() {
           frame.style.width = '100%';
           frame.style.height = '100%';
         }
+        // A non-default speed picked before the player finished loading (or
+        // carried over from the previous video) must survive the (re)build.
+        applyPlaybackRate();
       },
       onStateChange: (event) => {
         // 1 = playing → track time; anything else → stop the ticker.
@@ -199,14 +272,25 @@ function seek(seg) {
   }
 }
 
+watch(playbackRate, () => {
+  applyPlaybackRate();
+});
+
 watch(
   videoId,
-  (id) => {
+  (id, previous) => {
+    // A different song is a different key — a leftover transpose offset would
+    // silently show wrong chords for it.
+    if (previous !== undefined) {
+      transpose.value = 0;
+    }
     if (!id) {
       return;
     }
     if (player && typeof player.loadVideoById === 'function') {
       player.loadVideoById(id);
+      // loadVideoById resets the playback rate to 1 on some clients.
+      applyPlaybackRate();
     } else {
       build();
     }
@@ -256,6 +340,52 @@ onBeforeUnmount(() => {
         </div>
         <div class="chord-player-playhead" :style="playheadStyle"></div>
       </div>
+
+      <!-- Practice controls: playback speed for everyone; transpose (with a
+           capo hint) only where the host view opts in. -->
+      <div class="chord-player-controls">
+        <div class="chord-player-control">
+          <span class="lx-label" id="chordPlayerSpeedLabel">{{ $t('pages.playAlong.speed') }}</span>
+          <LxContentSwitcher
+            id="chordPlayerSpeedSwitcher"
+            :items="speedOptions"
+            v-model="speedId"
+            label-id="chordPlayerSpeedLabel"
+          />
+        </div>
+        <div v-if="hasTranspose" class="chord-player-control">
+          <span class="lx-label">{{ $t('pages.playAlong.transpose') }}</span>
+          <LxButton
+            id="chordPlayerTransposeDown"
+            :label="$t('pages.playAlong.transposeDown')"
+            icon="subtract"
+            variant="icon-only"
+            kind="ghost"
+            :disabled="transpose <= TRANSPOSE_MIN"
+            @click="bumpTranspose(-1)"
+          />
+          <span class="chord-player-transpose-value lx-data">{{ transposeLabel }}</span>
+          <LxButton
+            id="chordPlayerTransposeUp"
+            :label="$t('pages.playAlong.transposeUp')"
+            icon="add"
+            variant="icon-only"
+            kind="ghost"
+            :disabled="transpose >= TRANSPOSE_MAX"
+            @click="bumpTranspose(1)"
+          />
+          <LxButton
+            v-if="transpose !== 0"
+            id="chordPlayerTransposeReset"
+            :label="$t('pages.playAlong.transposeReset')"
+            icon="undo"
+            variant="icon-only"
+            kind="ghost"
+            @click="transpose = 0"
+          />
+          <span v-if="capoHint" class="lx-secondary chord-player-capo-hint">{{ capoHint }}</span>
+        </div>
+      </div>
     </div>
 
     <!-- Fingering panel: a static reference with one diagram per distinct
@@ -297,6 +427,28 @@ onBeforeUnmount(() => {
   gap: 1rem;
   min-width: 0;
   flex: 1 1 auto;
+}
+
+/* Practice controls ------------------------------------------------------- */
+.chord-player-controls {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem 1.5rem;
+}
+.chord-player-control {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  min-width: 0;
+}
+.chord-player-transpose-value {
+  min-width: 2ch;
+  text-align: center;
+  font-variant-numeric: tabular-nums;
+}
+.chord-player-capo-hint {
+  white-space: nowrap;
 }
 
 /* Diagram side panel ------------------------------------------------------ */

--- a/src/components/ChordSvg.vue
+++ b/src/components/ChordSvg.vue
@@ -1,5 +1,10 @@
 <script setup>
 import { computed, shallowRef, watchEffect } from 'vue';
+import { useI18n } from 'vue-i18n';
+
+import { parseChordName, dbSuffix, dbRoot } from '@/utils/chordName';
+
+const { t: $t } = useI18n();
 
 const props = defineProps({
   chord: {
@@ -32,21 +37,6 @@ const actualWidth = computed(() => {
   if (props.width) return props.width;
   return props.instrument === 'ukulele' || props.instrument === 'baritone-ukulele' ? 100 : 120;
 });
-
-const suffixMapping = {
-  '': 'major',
-  m: 'minor',
-  min: 'minor',
-  maj: 'major',
-  dim: 'dim',
-  diminished: 'dim',
-  aug: 'aug',
-  augmented: 'aug',
-  maj7add9: 'maj9',
-  '7add9': '9',
-  m7add9: 'm9',
-  5: '5',
-};
 
 const currentDb = shallowRef(null);
 
@@ -88,6 +78,16 @@ const instrumentSettings = computed(() => {
   };
 });
 
+// Parsed identity of the requested chord — via explicit root/suffix props
+// (chords library) or by parsing the free-form label (play-along timelines).
+// Slash chords parse into root/suffix/bass; garbage parses to null.
+const parsed = computed(() => {
+  if (props.root && props.suffix !== undefined) {
+    return { root: props.root, suffix: props.suffix, bass: null };
+  }
+  return parseChordName(props.chord || '');
+});
+
 const romanMap = {
   3: 'III',
   5: 'V',
@@ -100,66 +100,17 @@ const romanMap = {
   21: 'XXI',
 };
 
-function normalizeRoot(rawRoot, instrument) {
-  let root = rawRoot;
-  // Common mappings (Sharps to Flats where common)
-  const commonMapping = {
-    'A#': 'Bb',
-    'D#': 'Eb',
-    'G#': 'Ab',
-  };
-
-  if (commonMapping[root]) {
-    root = commonMapping[root];
-  }
-
-  if (instrument === 'ukulele') {
-    // Ukulele uses Flats for C# and F#
-    const ukeMapping = {
-      'C#': 'Db',
-      'F#': 'Gb',
-    };
-    if (ukeMapping[root]) {
-      root = ukeMapping[root];
-    }
-  } else {
-    // Guitar uses Csharp and Fsharp spelled out
-    // Maps C#/Db -> Csharp and F#/Gb -> Fsharp
-    const guitarMapping = {
-      Db: 'Csharp',
-      'C#': 'Csharp',
-      Gb: 'Fsharp',
-      'F#': 'Fsharp',
-    };
-    if (guitarMapping[root]) {
-      root = guitarMapping[root];
-    }
-  }
-  return root;
-}
-
+// Fingering positions for the requested chord. Slash chords fall back to the
+// base chord's fingering (D/F# → D shapes) — the displayed name keeps the
+// full label, and any bass-note nuance is a player's choice anyway. Chords
+// the database simply doesn't know resolve to null and render as a name-only
+// tile instead of disappearing.
 const chordData = computed(() => {
-  let root;
-  let suffix;
+  if (!parsed.value || !instrumentSettings.value.db) return null;
 
-  if (props.root && props.suffix !== undefined) {
-    root = props.root;
-    suffix = props.suffix;
-  } else if (props.chord) {
-    const match = props.chord.match(/^([A-G][#b]?)(.*)$/);
-    if (!match) return null;
-    [, root, suffix] = match;
-  } else {
-    return null;
-  }
+  const root = dbRoot(parsed.value.root, props.instrument);
+  const suffix = dbSuffix(parsed.value.suffix);
 
-  root = normalizeRoot(root, props.instrument);
-
-  if (suffixMapping[suffix]) {
-    suffix = suffixMapping[suffix];
-  }
-
-  if (!instrumentSettings.value.db) return null;
   const chordEntry = instrumentSettings.value.db.chords[root];
   if (!chordEntry) return null;
 
@@ -410,12 +361,41 @@ const renderData = computed(() => {
       </text>
     </svg>
   </div>
+  <!-- Name-only tile for chords the database has no fingering for — the
+       chord stays visible in diagram grids instead of silently vanishing.
+       Only shown once the db has loaded, so it can't flash during the async
+       import. -->
+  <div
+    v-else-if="currentDb && displayChordName"
+    class="chord-svg-container chord-svg-fallback"
+    :style="{ width: actualWidth + 'px', height: props.height + 'px' }"
+    :title="$t('chordDiagram.unavailable')"
+  >
+    <span class="chord-svg-fallback-name">{{ displayChordName }}</span>
+  </div>
 </template>
 
 <style scoped>
 .chord-svg-container {
   display: inline-block;
   margin: 4px;
+}
+
+.chord-svg-fallback {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  box-sizing: border-box;
+  border: 1px dashed var(--color-chrome);
+  border-radius: 4px;
+}
+
+.chord-svg-fallback-name {
+  color: var(--color-data);
+  font-size: 20px;
+  text-align: center;
+  padding: 0 4px;
+  overflow-wrap: anywhere;
 }
 
 .string-line {

--- a/src/locales/ee.json
+++ b/src/locales/ee.json
@@ -218,7 +218,13 @@
             "changesIn": "pärast",
             "songEnd": "Laulu lõpp",
             "seconds": "s",
-            "generateOwn": "Sellel laulul pole akordide ajaskaalat? Proovi seda ise genereerida."
+            "generateOwn": "Sellel laulul pole akordide ajaskaalat? Proovi seda ise genereerida.",
+            "speed": "Kiirus",
+            "transpose": "Transponeeri",
+            "transposeUp": "Pooltoon kõrgemale",
+            "transposeDown": "Pooltoon madalamale",
+            "transposeReset": "Taasta algne helistik",
+            "capoHint": "Capo {fret}. vahel kõlab originaalhelistikus"
         },
         "chordGenerator": {
             "title": "Akordigeneraator",
@@ -241,6 +247,10 @@
                 "eta": "Eeldatav ooteaeg: {eta}",
                 "none": "Järjekord on hetkel tühi"
             },
+            "limit": {
+                "remaining": "Täna alles jäänud esitusi: {remaining} / {limit}",
+                "exhaustedUntil": "Päevalimiit on täis. Järgmine esitus võimalik: {time}"
+            },
             "status": {
                 "pending": "Ootab järjekorras...",
                 "position": "Sinu ees järjekorras: {count}",
@@ -256,8 +266,7 @@
             },
             "rating": {
                 "yours": "Sinu hinnang",
-                "average": "Keskmine hinnang",
-                "none": "Hinnanguid veel pole"
+                "average": "Keskmine hinnang"
             }
         },
         "akordiSongView": {
@@ -704,5 +713,8 @@
         "themeContrastDescription": "Suurendatud värvikontrastiga teema sisu loetavuse parandamiseks.",
         "transparencyLinkLabel": "Juurdepääsetavuse standardid (WCAG Contrast (Minimum))",
         "animationsLinkLabel": "Juurdepääsetavuse standardid (WCAG Animation from Interactions)"
+    },
+    "chordDiagram": {
+        "unavailable": "Diagramm pole saadaval"
     }
 }

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -218,7 +218,13 @@
             "changesIn": "en",
             "songEnd": "Fin de la canción",
             "seconds": "s",
-            "generateOwn": "¿No hay una línea de tiempo de acordes para esta canción? Prueba a generarla tú mismo."
+            "generateOwn": "¿No hay una línea de tiempo de acordes para esta canción? Prueba a generarla tú mismo.",
+            "speed": "Velocidad",
+            "transpose": "Transportar",
+            "transposeUp": "Un semitono más alto",
+            "transposeDown": "Un semitono más bajo",
+            "transposeReset": "Restablecer tonalidad",
+            "capoHint": "Con cejilla en el traste {fret} suena en la tonalidad original"
         },
         "chordGenerator": {
             "title": "Generador de acordes",
@@ -241,6 +247,10 @@
                 "eta": "Tiempo de espera estimado: {eta}",
                 "none": "La cola está vacía en este momento"
             },
+            "limit": {
+                "remaining": "Envíos restantes hoy: {remaining} de {limit}",
+                "exhaustedUntil": "Límite diario alcanzado. Próximo envío posible: {time}"
+            },
             "status": {
                 "pending": "Esperando en la cola...",
                 "position": "Por delante en la cola: {count}",
@@ -256,8 +266,7 @@
             },
             "rating": {
                 "yours": "Tu valoración",
-                "average": "Valoración media",
-                "none": "Todavía no hay valoraciones"
+                "average": "Valoración media"
             }
         },
         "akordiSongView": {
@@ -704,5 +713,8 @@
         "themeContrastDescription": "Tema con mayor contraste de color para mejorar la legibilidad del contenido.",
         "transparencyLinkLabel": "Estándares de accesibilidad (WCAG Contrast (Minimum))",
         "animationsLinkLabel": "Estándares de accesibilidad (WCAG Animation from Interactions)"
+    },
+    "chordDiagram": {
+        "unavailable": "Diagrama no disponible"
     }
 }

--- a/src/locales/lt.json
+++ b/src/locales/lt.json
@@ -218,7 +218,13 @@
             "changesIn": "po",
             "songEnd": "Dainos pabaiga",
             "seconds": "s",
-            "generateOwn": "Nėra akordų laiko juostos šiai dainai? Pabandyk sugeneruoti pats."
+            "generateOwn": "Nėra akordų laiko juostos šiai dainai? Pabandyk sugeneruoti pats.",
+            "speed": "Greitis",
+            "transpose": "Transponuoti",
+            "transposeUp": "Pustoniu aukščiau",
+            "transposeDown": "Pustoniu žemiau",
+            "transposeReset": "Atstatyti tonaciją",
+            "capoHint": "Su capo {fret} skambės originalia tonacija"
         },
         "chordGenerator": {
             "title": "Akordų generatorius",
@@ -241,6 +247,10 @@
                 "eta": "Numatomas laukimo laikas: {eta}",
                 "none": "Eilė šiuo metu tuščia"
             },
+            "limit": {
+                "remaining": "Šiandien liko pateikimų: {remaining} iš {limit}",
+                "exhaustedUntil": "Dienos limitas pasiektas. Kitas pateikimas galimas: {time}"
+            },
             "status": {
                 "pending": "Laukiama eilėje...",
                 "position": "Prieš tave eilėje: {count}",
@@ -256,8 +266,7 @@
             },
             "rating": {
                 "yours": "Tavo įvertinimas",
-                "average": "Vidutinis įvertinimas",
-                "none": "Kol kas nėra įvertinimų"
+                "average": "Vidutinis įvertinimas"
             }
         },
         "akordiSongView": {
@@ -704,5 +713,8 @@
         "themeContrastDescription": "Tema su padidintu spalvų kontrastu, pagerinanti turinio skaitomumą.",
         "transparencyLinkLabel": "Prieinamumo standartai (WCAG Contrast (Minimum))",
         "animationsLinkLabel": "Prieinamumo standartai (WCAG Animation from Interactions)"
+    },
+    "chordDiagram": {
+        "unavailable": "Diagrama nepasiekiama"
     }
 }

--- a/src/locales/lv.json
+++ b/src/locales/lv.json
@@ -218,7 +218,13 @@
             "changesIn": "pēc",
             "songEnd": "Dziesmas beigas",
             "seconds": "s",
-            "generateOwn": "Nav akordu laika skalas šai dziesmai? Izmēģini ģenerēt to pats."
+            "generateOwn": "Nav akordu laika skalas šai dziesmai? Izmēģini ģenerēt to pats.",
+            "speed": "Ātrums",
+            "transpose": "Transponēt",
+            "transposeUp": "Pustoni augstāk",
+            "transposeDown": "Pustoni zemāk",
+            "transposeReset": "Atiestatīt tonalitāti",
+            "capoHint": "Ar capo {fret}. zīmē skan oriģinālā tonalitāte"
         },
         "chordGenerator": {
             "title": "Akordu ģenerators",
@@ -241,6 +247,10 @@
                 "eta": "Aptuvenais gaidīšanas laiks: {eta}",
                 "none": "Rinda pašlaik ir tukša"
             },
+            "limit": {
+                "remaining": "Šodien atlikuši iesniegumi: {remaining} no {limit}",
+                "exhaustedUntil": "Dienas limits sasniegts. Nākamais iesniegums iespējams: {time}"
+            },
             "status": {
                 "pending": "Rindā gaida apstrādi...",
                 "position": "Priekšā rindā: {count}",
@@ -256,8 +266,7 @@
             },
             "rating": {
                 "yours": "Tavs vērtējums",
-                "average": "Vidējais vērtējums",
-                "none": "Vēl nav vērtējumu"
+                "average": "Vidējais vērtējums"
             }
         },
         "akordiSongView": {
@@ -704,5 +713,8 @@
         "themeContrastDescription": "Noformējums ar paaugstinātu krāsu kontrastu, kas uzlabo satura salasāmību.",
         "transparencyLinkLabel": "Piekļūstamības standarti (WCAG Contrast (Minimum))",
         "animationsLinkLabel": "Piekļūstamības standarti (WCAG Animation from Interactions)"
+    },
+    "chordDiagram": {
+        "unavailable": "Diagramma nav pieejama"
     }
 }

--- a/src/services/chordgenSongService.js
+++ b/src/services/chordgenSongService.js
@@ -26,6 +26,10 @@ export default {
     return http(serviceUrl).get(`/me/chordgen-songs/jobs/${jobId}`);
   },
 
+  getMyLimit() {
+    return http(serviceUrl).get('/me/chordgen-songs/limit');
+  },
+
   getMyRating(id) {
     return http(serviceUrl).get(`/me/chordgen-songs/${id}/rating`);
   },

--- a/src/utils/chordName.js
+++ b/src/utils/chordName.js
@@ -1,0 +1,166 @@
+// Pure helpers for chord-name parsing, spelling, and transposition. Kept
+// framework-free so they can be unit-tested without a DOM, and shared between
+// the chord diagram renderer (ChordSvg) and the play-along transpose control.
+
+// Semitone index for every root spelling we accept. Sharp and flat spellings
+// of the same pitch map to the same index.
+const NOTE_INDEX = {
+  C: 0,
+  'C#': 1,
+  Db: 1,
+  D: 2,
+  'D#': 3,
+  Eb: 3,
+  E: 4,
+  F: 5,
+  'F#': 6,
+  Gb: 6,
+  G: 7,
+  'G#': 8,
+  Ab: 8,
+  A: 9,
+  'A#': 10,
+  Bb: 10,
+  B: 11,
+};
+
+const SHARP_SCALE = ['C', 'C#', 'D', 'D#', 'E', 'F', 'F#', 'G', 'G#', 'A', 'A#', 'B'];
+const FLAT_SCALE = ['C', 'Db', 'D', 'Eb', 'E', 'F', 'Gb', 'G', 'Ab', 'A', 'Bb', 'B'];
+
+/**
+ * Split a chord label into root, suffix, and optional slash bass note.
+ * Examples: 'Am7' → {root:'A', suffix:'m7', bass:null};
+ * 'D/F#' → {root:'D', suffix:'', bass:'F#'}.
+ * Returns null when the label does not start with a recognisable root or the
+ * slash bass is not a valid note.
+ * @param {string} label
+ * @returns {{root:string, suffix:string, bass:string|null}|null}
+ */
+export function parseChordName(label) {
+  if (typeof label !== 'string') {
+    return null;
+  }
+  const match = label.trim().match(/^([A-G][#b]?)([^/]*)(?:\/([A-G][#b]?))?$/);
+  if (!match) {
+    return null;
+  }
+  const [, root, suffix, bass] = match;
+  if (NOTE_INDEX[root] === undefined) {
+    return null;
+  }
+  if (bass !== undefined && NOTE_INDEX[bass] === undefined) {
+    return null;
+  }
+  return { root, suffix: suffix || '', bass: bass || null };
+}
+
+function transposeNote(note, semitones, preferFlats) {
+  const index = NOTE_INDEX[note];
+  const next = (((index + semitones) % 12) + 12) % 12;
+  return preferFlats ? FLAT_SCALE[next] : SHARP_SCALE[next];
+}
+
+/**
+ * Transpose a chord label by the given number of semitones, keeping the
+ * suffix intact and transposing a slash bass along with the root. Spelling
+ * follows the original label: a flat root stays in the flat scale, everything
+ * else uses sharps. Labels that don't parse are returned unchanged so a
+ * transposed timeline never loses chords it can't interpret.
+ * @param {string} label
+ * @param {number} semitones positive or negative
+ * @returns {string}
+ */
+export function transposeChord(label, semitones) {
+  const offset = Number(semitones);
+  if (!Number.isFinite(offset) || offset === 0) {
+    return label;
+  }
+  const parsed = parseChordName(label);
+  if (!parsed) {
+    return label;
+  }
+  const preferFlats = parsed.root.includes('b');
+  let out = transposeNote(parsed.root, offset, preferFlats) + parsed.suffix;
+  if (parsed.bass) {
+    out += `/${transposeNote(parsed.bass, offset, parsed.bass.includes('b'))}`;
+  }
+  return out;
+}
+
+/**
+ * The capo fret that makes chords transposed DOWN by `semitones` sound in the
+ * original key: displayed + capo ≡ original (mod 12). Only frets 1..11 are
+ * meaningful — 0 means "no capo needed" (offset 0).
+ * @param {number} semitones the display transpose offset (any sign)
+ * @returns {number} 0..11
+ */
+export function capoForOffset(semitones) {
+  const offset = Number(semitones);
+  if (!Number.isFinite(offset)) {
+    return 0;
+  }
+  return ((-offset % 12) + 12) % 12;
+}
+
+// Suffix spellings that chords-db stores under a different name.
+const DB_SUFFIX_ALIASES = {
+  '': 'major',
+  m: 'minor',
+  min: 'minor',
+  maj: 'major',
+  dim: 'dim',
+  diminished: 'dim',
+  aug: 'aug',
+  augmented: 'aug',
+  maj7add9: 'maj9',
+  '7add9': '9',
+  m7add9: 'm9',
+  5: '5',
+};
+
+/**
+ * Map a chord suffix to the name chords-db uses; suffixes without an alias
+ * (sus4, add9, 7, ...) are already db names and pass through unchanged.
+ * @param {string} suffix
+ * @returns {string}
+ */
+export function dbSuffix(suffix) {
+  return DB_SUFFIX_ALIASES[suffix] !== undefined ? DB_SUFFIX_ALIASES[suffix] : suffix;
+}
+
+/**
+ * Rewrite a root note into the spelling a chords-db instrument database keys
+ * on: common sharps become flats everywhere; the ukulele db additionally uses
+ * Db/Gb, while the guitar db spells those roots Csharp/Fsharp.
+ * @param {string} rawRoot
+ * @param {string} instrument 'guitar' | 'ukulele' | 'baritone-ukulele'
+ * @returns {string}
+ */
+export function dbRoot(rawRoot, instrument) {
+  let root = rawRoot;
+  const commonMapping = {
+    'A#': 'Bb',
+    'D#': 'Eb',
+    'G#': 'Ab',
+  };
+  if (commonMapping[root]) {
+    root = commonMapping[root];
+  }
+  if (instrument === 'ukulele') {
+    const ukeMapping = { 'C#': 'Db', 'F#': 'Gb' };
+    if (ukeMapping[root]) {
+      root = ukeMapping[root];
+    }
+  } else {
+    const guitarMapping = {
+      Db: 'Csharp',
+      'C#': 'Csharp',
+      Gb: 'Fsharp',
+      'F#': 'Fsharp',
+    };
+    if (guitarMapping[root]) {
+      root = guitarMapping[root];
+    }
+  }
+  return root;
+}

--- a/src/utils/chordName.js
+++ b/src/utils/chordName.js
@@ -40,7 +40,7 @@ export function parseChordName(label) {
   if (typeof label !== 'string') {
     return null;
   }
-  const match = label.trim().match(/^([A-G][#b]?)([^/]*)(?:\/([A-G][#b]?))?$/);
+  const match = /^([A-G][#b]?)([^/]*)(?:\/([A-G][#b]?))?$/.exec(label.trim());
   if (!match) {
     return null;
   }

--- a/src/views/ChordGeneratorList.vue
+++ b/src/views/ChordGeneratorList.vue
@@ -88,13 +88,15 @@ onMounted(async () => {
     </template>
     <template #customItem="{ title, averageRating, ratingsCount }">
       <p class="lx-primary">{{ title }}</p>
-      <div class="lx-secondary" style="display: flex; align-items: center; gap: 0.35rem">
+      <!-- Rating shown only once a song has been rated — empty stars with a
+           "no ratings" note next to every fresh song read as clutter. -->
+      <div
+        v-if="ratingsCount > 0"
+        class="lx-secondary"
+        style="display: flex; align-items: center; gap: 0.35rem"
+      >
         <LxRating :model-value="averageRating" read-only kind="5stars" :focusable="false" />
-        <span>{{
-          ratingsCount > 0
-            ? `${averageRating.toFixed(1)} (${ratingsCount})`
-            : $t('pages.chordGenerator.rating.none')
-        }}</span>
+        <span>{{ `${averageRating.toFixed(1)} (${ratingsCount})` }}</span>
       </div>
     </template>
     <template #empty>

--- a/src/views/ChordGeneratorSubmit.vue
+++ b/src/views/ChordGeneratorSubmit.vue
@@ -167,15 +167,11 @@ async function loadQueue() {
 }
 
 async function loadLimit() {
-  try {
-    const resp = await chordgenSongService.getMyLimit();
-    limitStatus.value = resp.data;
-  } catch (err) {
-    // Non-critical: without allowance info the form behaves as before (the
-    // server still enforces the limit on submit). Clearing the state also
-    // drops a stale allowance line rather than showing outdated numbers.
-    limitStatus.value = null;
-  }
+  // Non-critical: without allowance info the form behaves as before (the
+  // server still enforces the limit on submit). A failed fetch clears the
+  // state so no stale allowance line lingers.
+  const resp = await chordgenSongService.getMyLimit().catch(() => null);
+  limitStatus.value = resp?.data ?? null;
 }
 
 // Best-effort split of a YouTube video title into artist/title, for the

--- a/src/views/ChordGeneratorSubmit.vue
+++ b/src/views/ChordGeneratorSubmit.vue
@@ -171,8 +171,10 @@ async function loadLimit() {
     const resp = await chordgenSongService.getMyLimit();
     limitStatus.value = resp.data;
   } catch (err) {
-    // Non-critical: without allowance info the form just behaves as before
-    // (the server still enforces the limit on submit).
+    // Non-critical: without allowance info the form behaves as before (the
+    // server still enforces the limit on submit). Clearing the state also
+    // drops a stale allowance line rather than showing outdated numbers.
+    limitStatus.value = null;
   }
 }
 

--- a/src/views/ChordGeneratorSubmit.vue
+++ b/src/views/ChordGeneratorSubmit.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { LxButton, LxForm, LxInfoBox, LxRow, LxTextInput } from '@dativa-lv/lx-ui';
+import { LxButton, LxForm, LxInfoBox, LxRow, LxTextInput, lxDateUtils } from '@dativa-lv/lx-ui';
 import { computed, onMounted, onUnmounted, ref } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { useRoute, useRouter } from 'vue-router';
@@ -35,11 +35,17 @@ const v = useVuelidate(rules, item);
 const submitting = ref(false);
 const jobStatus = ref(null);
 const queue = ref(null);
+// Daily submission allowance for the signed-in user, from
+// GET /me/chordgen-songs/limit. Null until loaded (or when the fetch fails) —
+// everything reading it must degrade to "no allowance info".
+const limitStatus = ref(null);
 
 const POLL_INTERVAL_MS = 3000;
 const POLL_TIMEOUT_MS = 20 * 60 * 1000;
 let pollTimer = null;
 let pollDeadline = null;
+
+const limitExhausted = computed(() => limitStatus.value?.remaining === 0);
 
 const formActions = computed(() => [
   {
@@ -48,6 +54,9 @@ const formActions = computed(() => [
     name: $t('pages.chordGenerator.form.submit'),
     kind: 'primary',
     busy: submitting.value,
+    // No point submitting into a guaranteed 429 — the status box explains
+    // when the next slot frees up.
+    disabled: limitExhausted.value,
   },
   { id: 'cancel', icon: 'cancel', name: $t('cancel'), kind: 'secondary' },
 ]);
@@ -78,6 +87,43 @@ const queueMessage = computed(() => {
     return depth;
   }
   return `${depth} · ${$t('pages.chordGenerator.queue.eta', { eta: wait })}`;
+});
+
+// Allowance line for the idle status box: how many submissions are left
+// today, or — when they're used up — when the next slot frees.
+const limitMessage = computed(() => {
+  if (!limitStatus.value) {
+    return '';
+  }
+  if (limitExhausted.value) {
+    const time = limitStatus.value.resetAt
+      ? lxDateUtils.formatDateTime(limitStatus.value.resetAt)
+      : null;
+    return time
+      ? $t('pages.chordGenerator.limit.exhaustedUntil', { time })
+      : $t('pages.chordGenerator.status.rateLimited');
+  }
+  return $t('pages.chordGenerator.limit.remaining', {
+    remaining: limitStatus.value.remaining,
+    limit: limitStatus.value.limit,
+  });
+});
+
+// The idle status box: queue snapshot as the headline with the allowance as
+// detail — flipped (and turned into a warning) when the allowance is used up,
+// since that's the thing actually stopping the user.
+const idleStatusBox = computed(() => {
+  if (limitExhausted.value) {
+    return { label: limitMessage.value, description: queueMessage.value, variant: 'warning' };
+  }
+  if (!queueMessage.value && !limitMessage.value) {
+    return null;
+  }
+  return {
+    label: queueMessage.value || limitMessage.value,
+    description: queueMessage.value ? limitMessage.value : '',
+    variant: 'info',
+  };
 });
 
 // While a job is in flight the same info box switches to live job status —
@@ -117,6 +163,16 @@ async function loadQueue() {
     queue.value = resp.data;
   } catch (err) {
     // Non-critical banner — a failed fetch just means no banner is shown.
+  }
+}
+
+async function loadLimit() {
+  try {
+    const resp = await chordgenSongService.getMyLimit();
+    limitStatus.value = resp.data;
+  } catch (err) {
+    // Non-critical: without allowance info the form just behaves as before
+    // (the server still enforces the limit on submit).
   }
 }
 
@@ -254,6 +310,9 @@ async function onSubmit() {
     if (data.status === 'pending') {
       jobStatus.value = { status: 'pending' };
       startPolling(data.id);
+      // The accepted submission consumed an allowance slot — keep the
+      // status box honest for when the job finishes.
+      loadLimit();
       return;
     }
     if (data.status === 'exists' || data.status === 'cached') {
@@ -265,7 +324,16 @@ async function onSubmit() {
   } catch (err) {
     submitting.value = false;
     if (err?.response?.status === 429) {
-      notificationStore.pushError($t('pages.chordGenerator.status.rateLimited'));
+      // The 429 body carries the reset time — tell the user when they can
+      // try again, and sync the allowance box so the form disables itself.
+      const resetAt = err.response.data?.resetAt;
+      const time = resetAt ? lxDateUtils.formatDateTime(resetAt) : null;
+      notificationStore.pushError(
+        time
+          ? $t('pages.chordGenerator.limit.exhaustedUntil', { time })
+          : $t('pages.chordGenerator.status.rateLimited')
+      );
+      loadLimit();
       return;
     }
     notificationStore.pushError($t('pages.chordGenerator.errors.submitFailed'));
@@ -294,7 +362,7 @@ onMounted(async () => {
     item.value.title = String(route.query.title);
   }
   if (isAuthorized) {
-    await loadQueue();
+    await Promise.all([loadQueue(), loadLimit()]);
     await guessArtistTitle();
   }
 });
@@ -329,8 +397,12 @@ onUnmounted(() => {
     <LxRow v-if="jobStatus">
       <LxInfoBox :label="progressLabel" :description="progressDescription" variant="info" />
     </LxRow>
-    <LxRow v-else-if="queueMessage">
-      <LxInfoBox :label="queueMessage" variant="info" />
+    <LxRow v-else-if="idleStatusBox">
+      <LxInfoBox
+        :label="idleStatusBox.label"
+        :description="idleStatusBox.description"
+        :variant="idleStatusBox.variant"
+      />
     </LxRow>
     <LxForm
       :action-definitions="formActions"

--- a/src/views/ChordGeneratorView.vue
+++ b/src/views/ChordGeneratorView.vue
@@ -106,6 +106,7 @@ onMounted(async () => {
       :segments="song.segments"
       :duration="song.duration"
       show-diagrams
+      has-transpose
       :instrument="settingsStore.instrument"
       @update:instrument="selectInstrument"
     />

--- a/tests/unit/chordGeneratorSubmit.test.js
+++ b/tests/unit/chordGeneratorSubmit.test.js
@@ -2,10 +2,11 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { mount, flushPromises } from '@vue/test-utils';
 import { ref } from 'vue';
 
-const { submit, getMyJob, getQueue, pushError } = vi.hoisted(() => ({
+const { submit, getMyJob, getQueue, getMyLimit, pushError } = vi.hoisted(() => ({
   submit: vi.fn(),
   getMyJob: vi.fn(),
   getQueue: vi.fn(),
+  getMyLimit: vi.fn(),
   pushError: vi.fn(),
 }));
 
@@ -29,6 +30,7 @@ vi.mock('@dativa-lv/lx-ui', () => ({
     emits: ['update:modelValue', 'blur'],
     template: '<input />',
   },
+  lxDateUtils: { formatDateTime: (value) => `fmt:${value}` },
 }));
 vi.mock('@vuelidate/core', () => ({
   default: () =>
@@ -40,7 +42,7 @@ vi.mock('@vuelidate/validators', () => ({
   url: {},
 }));
 vi.mock('@/services/chordgenSongService', () => ({
-  default: { submit, getMyJob, getQueue },
+  default: { submit, getMyJob, getQueue, getMyLimit },
 }));
 vi.mock('vue-i18n', () => ({ useI18n: () => ({ t: (key) => key }) }));
 vi.mock('vue-router', () => ({
@@ -69,9 +71,14 @@ const queueSnapshot = (overrides = {}) => ({
   },
 });
 
+const limitSnapshot = (overrides = {}) => ({
+  data: { limit: 5, used: 0, remaining: 5, ...overrides },
+});
+
 beforeEach(() => {
   vi.clearAllMocks();
   vi.useFakeTimers();
+  getMyLimit.mockResolvedValue(limitSnapshot());
   // oEmbed title guess — irrelevant here, always fails silently.
   vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('offline')));
 });
@@ -90,7 +97,9 @@ describe('ChordGeneratorSubmit persistent status box', () => {
     expect(getQueue).toHaveBeenCalledTimes(1);
     const box = wrapper.findComponent({ name: 'LxInfoBox' });
     expect(box.props('label')).toBe('pages.chordGenerator.queue.none');
-    expect(box.props('description')).toBeFalsy();
+    // The allowance line rides along as the description.
+    expect(box.props('description')).toBe('pages.chordGenerator.limit.remaining');
+    expect(box.props('variant')).toBe('info');
   });
 
   it('replaces the snapshot with a live progress panel and re-fetches the queue on every poll', async () => {
@@ -134,5 +143,81 @@ describe('ChordGeneratorSubmit persistent status box', () => {
     const box = wrapper.findComponent({ name: 'LxInfoBox' });
     expect(box.props('label')).toBe('pages.chordGenerator.status.running');
     expect(box.props('description')).toBe('');
+  });
+});
+
+describe('ChordGeneratorSubmit daily allowance', () => {
+  it('turns the status box into a warning and disables submit when exhausted', async () => {
+    getQueue.mockResolvedValue(queueSnapshot());
+    getMyLimit.mockResolvedValue(
+      limitSnapshot({ used: 5, remaining: 0, resetAt: '2026-08-03T05:00:00Z' })
+    );
+
+    const wrapper = mount(ChordGeneratorSubmit);
+    await flushPromises();
+
+    const box = wrapper.findComponent({ name: 'LxInfoBox' });
+    expect(box.props('variant')).toBe('warning');
+    // The exhausted message (with the reset time) leads; the queue snapshot
+    // becomes the detail line.
+    expect(box.props('label')).toBe('pages.chordGenerator.limit.exhaustedUntil');
+    expect(box.props('description')).toBe('pages.chordGenerator.queue.none');
+
+    const actions = wrapper.findComponent({ name: 'LxForm' }).props('actionDefinitions');
+    expect(actions.find((a) => a.id === 'submit').disabled).toBe(true);
+  });
+
+  it('keeps submit enabled while slots remain', async () => {
+    getQueue.mockResolvedValue(queueSnapshot());
+    getMyLimit.mockResolvedValue(limitSnapshot({ used: 3, remaining: 2 }));
+
+    const wrapper = mount(ChordGeneratorSubmit);
+    await flushPromises();
+
+    const actions = wrapper.findComponent({ name: 'LxForm' }).props('actionDefinitions');
+    expect(actions.find((a) => a.id === 'submit').disabled).toBe(false);
+  });
+
+  it('refreshes the allowance after an accepted submission', async () => {
+    getQueue.mockResolvedValue(queueSnapshot());
+    submit.mockResolvedValue({ data: { status: 'pending', id: 'job-1' } });
+    getMyJob.mockResolvedValue({ data: { status: 'pending' } });
+
+    const wrapper = mount(ChordGeneratorSubmit);
+    await flushPromises();
+    expect(getMyLimit).toHaveBeenCalledTimes(1);
+
+    wrapper.findComponent({ name: 'LxForm' }).vm.$emit('action-click', 'submit');
+    await flushPromises();
+    expect(getMyLimit).toHaveBeenCalledTimes(2);
+  });
+
+  it('surfaces the reset time from a 429 and re-syncs the allowance', async () => {
+    getQueue.mockResolvedValue(queueSnapshot());
+    submit.mockRejectedValue({
+      response: { status: 429, data: { limit: 5, remaining: 0, resetAt: '2026-08-03T05:00:00Z' } },
+    });
+
+    const wrapper = mount(ChordGeneratorSubmit);
+    await flushPromises();
+    expect(getMyLimit).toHaveBeenCalledTimes(1);
+
+    wrapper.findComponent({ name: 'LxForm' }).vm.$emit('action-click', 'submit');
+    await flushPromises();
+
+    expect(pushError).toHaveBeenCalledWith('pages.chordGenerator.limit.exhaustedUntil');
+    expect(getMyLimit).toHaveBeenCalledTimes(2);
+  });
+
+  it('falls back to the generic message when a 429 has no reset time', async () => {
+    getQueue.mockResolvedValue(queueSnapshot());
+    submit.mockRejectedValue({ response: { status: 429, data: {} } });
+
+    const wrapper = mount(ChordGeneratorSubmit);
+    await flushPromises();
+    wrapper.findComponent({ name: 'LxForm' }).vm.$emit('action-click', 'submit');
+    await flushPromises();
+
+    expect(pushError).toHaveBeenCalledWith('pages.chordGenerator.status.rateLimited');
   });
 });

--- a/tests/unit/chordName.test.js
+++ b/tests/unit/chordName.test.js
@@ -1,0 +1,125 @@
+import { describe, it, expect } from 'vitest';
+import {
+  parseChordName,
+  transposeChord,
+  capoForOffset,
+  dbSuffix,
+  dbRoot,
+} from '@/utils/chordName';
+
+describe('parseChordName', () => {
+  it('parses plain majors and minors', () => {
+    expect(parseChordName('C')).toEqual({ root: 'C', suffix: '', bass: null });
+    expect(parseChordName('Am')).toEqual({ root: 'A', suffix: 'm', bass: null });
+    expect(parseChordName('F#m7')).toEqual({ root: 'F#', suffix: 'm7', bass: null });
+    expect(parseChordName('Bbmaj7')).toEqual({ root: 'Bb', suffix: 'maj7', bass: null });
+  });
+
+  it('parses slash chords with a valid bass note', () => {
+    expect(parseChordName('D/F#')).toEqual({ root: 'D', suffix: '', bass: 'F#' });
+    expect(parseChordName('Am7/G')).toEqual({ root: 'A', suffix: 'm7', bass: 'G' });
+    expect(parseChordName('C/Bb')).toEqual({ root: 'C', suffix: '', bass: 'Bb' });
+  });
+
+  it('tolerates surrounding whitespace', () => {
+    expect(parseChordName(' G7 ')).toEqual({ root: 'G', suffix: '7', bass: null });
+  });
+
+  it('rejects garbage', () => {
+    expect(parseChordName('')).toBeNull();
+    expect(parseChordName('H')).toBeNull();
+    expect(parseChordName('X13')).toBeNull();
+    expect(parseChordName('C/QQ')).toBeNull();
+    expect(parseChordName(null)).toBeNull();
+    expect(parseChordName(42)).toBeNull();
+  });
+});
+
+describe('transposeChord', () => {
+  it('transposes up and down with wrap-around', () => {
+    expect(transposeChord('Am', 3)).toBe('Cm');
+    expect(transposeChord('C', -1)).toBe('B');
+    expect(transposeChord('B', 1)).toBe('C');
+    expect(transposeChord('G', 14)).toBe('A'); // > octave wraps
+    expect(transposeChord('D', -14)).toBe('C');
+  });
+
+  it('keeps the suffix intact', () => {
+    expect(transposeChord('Cmaj7', 2)).toBe('Dmaj7');
+    expect(transposeChord('F#m7b5', 1)).toBe('Gm7b5');
+    expect(transposeChord('Asus4', -2)).toBe('Gsus4');
+  });
+
+  it('transposes the slash bass along with the root', () => {
+    expect(transposeChord('D/F#', 2)).toBe('E/G#');
+    expect(transposeChord('C/G', -12)).toBe('C/G');
+    expect(transposeChord('Am7/G', 3)).toBe('Cm7/A#');
+  });
+
+  it('keeps flat spelling for flat roots, sharps otherwise', () => {
+    expect(transposeChord('Bb', 2)).toBe('C');
+    expect(transposeChord('Eb', 1)).toBe('E');
+    expect(transposeChord('Db', 2)).toBe('Eb');
+    expect(transposeChord('C#', 2)).toBe('D#');
+  });
+
+  it('returns the label unchanged for offset 0 or unparseable input', () => {
+    expect(transposeChord('Am', 0)).toBe('Am');
+    expect(transposeChord('N.C.', 3)).toBe('N.C.');
+    expect(transposeChord('', 3)).toBe('');
+    expect(transposeChord('Am', Number.NaN)).toBe('Am');
+  });
+});
+
+describe('capoForOffset', () => {
+  it('inverts the display offset mod 12', () => {
+    expect(capoForOffset(0)).toBe(0);
+    expect(capoForOffset(-2)).toBe(2); // shapes down 2 → capo 2 restores pitch
+    expect(capoForOffset(-11)).toBe(11);
+    expect(capoForOffset(3)).toBe(9);
+    expect(capoForOffset(12)).toBe(0);
+  });
+
+  it('is safe on garbage', () => {
+    expect(capoForOffset(Number.NaN)).toBe(0);
+    expect(capoForOffset(undefined)).toBe(0);
+  });
+});
+
+describe('dbSuffix', () => {
+  it('maps aliases to chords-db names', () => {
+    expect(dbSuffix('')).toBe('major');
+    expect(dbSuffix('m')).toBe('minor');
+    expect(dbSuffix('min')).toBe('minor');
+    expect(dbSuffix('dim')).toBe('dim');
+    expect(dbSuffix('5')).toBe('5');
+  });
+
+  it('passes through suffixes chords-db already uses', () => {
+    expect(dbSuffix('sus4')).toBe('sus4');
+    expect(dbSuffix('add9')).toBe('add9');
+    expect(dbSuffix('7')).toBe('7');
+    expect(dbSuffix('m7b5')).toBe('m7b5');
+  });
+});
+
+describe('dbRoot', () => {
+  it('flattens common sharps for every instrument', () => {
+    expect(dbRoot('A#', 'guitar')).toBe('Bb');
+    expect(dbRoot('D#', 'ukulele')).toBe('Eb');
+    expect(dbRoot('G#', 'baritone-ukulele')).toBe('Ab');
+  });
+
+  it('spells C#/F# per instrument database', () => {
+    expect(dbRoot('C#', 'guitar')).toBe('Csharp');
+    expect(dbRoot('Db', 'guitar')).toBe('Csharp');
+    expect(dbRoot('F#', 'baritone-ukulele')).toBe('Fsharp');
+    expect(dbRoot('C#', 'ukulele')).toBe('Db');
+    expect(dbRoot('F#', 'ukulele')).toBe('Gb');
+  });
+
+  it('leaves natural roots alone', () => {
+    expect(dbRoot('C', 'guitar')).toBe('C');
+    expect(dbRoot('G', 'ukulele')).toBe('G');
+  });
+});

--- a/tests/unit/chordPlayer.test.js
+++ b/tests/unit/chordPlayer.test.js
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { mount } from '@vue/test-utils';
 
 vi.mock('@dativa-lv/lx-ui', () => ({
@@ -8,6 +8,12 @@ vi.mock('@dativa-lv/lx-ui', () => ({
     emits: ['update:modelValue'],
     template: '<div />',
   },
+  LxButton: {
+    name: 'LxButton',
+    props: ['label', 'icon', 'disabled'],
+    emits: ['click'],
+    template: '<button :disabled="disabled" @click="$emit(\'click\')" />',
+  },
 }));
 vi.mock('@/components/ChordSvg.vue', () => ({
   default: {
@@ -16,9 +22,39 @@ vi.mock('@/components/ChordSvg.vue', () => ({
     template: '<div />',
   },
 }));
-vi.mock('vue-i18n', () => ({ useI18n: () => ({ t: (key) => key }) }));
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({
+    t: (key, params) => (params ? `${key}:${Object.values(params).join(',')}` : key),
+  }),
+}));
 
 import ChordPlayer from '@/components/ChordPlayer.vue';
+
+// Fake YouTube IFrame API: build() resolves immediately and onReady fires
+// synchronously, so tests can assert calls against the created player.
+let lastPlayer;
+class FakePlayer {
+  constructor(el, opts) {
+    lastPlayer = this;
+    this.setPlaybackRate = vi.fn();
+    this.seekTo = vi.fn();
+    this.playVideo = vi.fn();
+    this.loadVideoById = vi.fn();
+    this.destroy = vi.fn();
+    this.getIframe = () => ({ style: {} });
+    this.getCurrentTime = () => 0;
+    opts.events.onReady();
+  }
+}
+
+beforeEach(() => {
+  lastPlayer = undefined;
+  vi.stubGlobal('YT', { Player: FakePlayer });
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
 
 const segments = [
   { start: 0, end: 2, label: 'Am' },
@@ -27,47 +63,149 @@ const segments = [
   { start: 6, end: 8, label: 'G' },
 ];
 
-const mountPlayer = (props = {}) =>
-  mount(ChordPlayer, {
+async function mountPlayer(props = {}) {
+  const wrapper = mount(ChordPlayer, {
     props: { videoUrl: 'https://youtu.be/abc123def45', segments, duration: 8, ...props },
   });
+  // build() awaits the (already-resolved) API promise before creating the
+  // player — let those microtasks run.
+  await vi.waitFor(() => {
+    if (!lastPlayer) throw new Error('player not built yet');
+  });
+  return wrapper;
+}
+
+const speedSwitcher = (wrapper) =>
+  wrapper
+    .findAllComponents({ name: 'LxContentSwitcher' })
+    .find((c) => c.props('items')?.some((i) => i.id === '0.5'));
 
 describe('ChordPlayer chord diagram panel', () => {
-  it('is hidden by default so existing usages are unchanged', () => {
-    const wrapper = mountPlayer();
+  it('is hidden by default so existing usages are unchanged', async () => {
+    const wrapper = await mountPlayer();
     expect(wrapper.find('.chord-player-diagrams').exists()).toBe(false);
-    expect(wrapper.findComponent({ name: 'LxContentSwitcher' }).exists()).toBe(false);
   });
 
-  it('renders one diagram per distinct chord, in order of first appearance', () => {
-    const wrapper = mountPlayer({ showDiagrams: true });
+  it('renders one diagram per distinct chord, in order of first appearance', async () => {
+    const wrapper = await mountPlayer({ showDiagrams: true });
     const diagrams = wrapper.findAllComponents({ name: 'ChordSvg' });
     expect(diagrams.map((d) => d.props('chord'))).toEqual(['Am', 'C', 'G']);
   });
 
-  it('does not highlight diagrams in sync with playback (static reference only)', () => {
-    const wrapper = mountPlayer({ showDiagrams: true });
-    // The timeline is the only place tracking the current chord — the diagram
-    // panel stays static so there aren't two competing highlights.
+  it('does not highlight diagrams in sync with playback (static reference only)', async () => {
+    const wrapper = await mountPlayer({ showDiagrams: true });
     expect(wrapper.find('.chord-player-diagrams .is-active').exists()).toBe(false);
   });
 
   it('passes the instrument to diagrams and re-emits switcher changes', async () => {
-    const wrapper = mountPlayer({ showDiagrams: true, instrument: 'ukulele' });
+    const wrapper = await mountPlayer({ showDiagrams: true, instrument: 'ukulele' });
     const diagrams = wrapper.findAllComponents({ name: 'ChordSvg' });
     expect(diagrams.every((d) => d.props('instrument') === 'ukulele')).toBe(true);
 
-    const switcher = wrapper.findComponent({ name: 'LxContentSwitcher' });
-    expect(switcher.props('modelValue')).toBe('ukulele');
+    const switcher = wrapper
+      .findAllComponents({ name: 'LxContentSwitcher' })
+      .find((c) => c.props('modelValue') === 'ukulele');
     switcher.vm.$emit('update:modelValue', 'guitar');
     expect(wrapper.emitted('update:instrument')).toEqual([['guitar']]);
   });
 
-  it('hides the panel when segments carry no labels', () => {
-    const wrapper = mountPlayer({
+  it('hides the panel when segments carry no labels', async () => {
+    const wrapper = await mountPlayer({
       showDiagrams: true,
       segments: [{ start: 0, end: 2, label: '' }],
     });
     expect(wrapper.find('.chord-player-diagrams').exists()).toBe(false);
+  });
+});
+
+describe('ChordPlayer playback speed', () => {
+  it('offers 0.5×, 0.75×, and 1× with 1× selected by default', async () => {
+    const wrapper = await mountPlayer();
+    const switcher = speedSwitcher(wrapper);
+    expect(switcher.props('items').map((i) => i.id)).toEqual(['0.5', '0.75', '1']);
+    expect(switcher.props('modelValue')).toBe('1');
+  });
+
+  it('applies a selected speed to the player', async () => {
+    const wrapper = await mountPlayer();
+    speedSwitcher(wrapper).vm.$emit('update:modelValue', '0.75');
+    await wrapper.vm.$nextTick();
+    expect(lastPlayer.setPlaybackRate).toHaveBeenCalledWith(0.75);
+  });
+
+  it('re-applies the speed when a new video loads into the same player', async () => {
+    const wrapper = await mountPlayer();
+    speedSwitcher(wrapper).vm.$emit('update:modelValue', '0.5');
+    await wrapper.vm.$nextTick();
+    lastPlayer.setPlaybackRate.mockClear();
+
+    await wrapper.setProps({ videoUrl: 'https://youtu.be/XYZ123def45' });
+    expect(lastPlayer.loadVideoById).toHaveBeenCalledWith('XYZ123def45');
+    expect(lastPlayer.setPlaybackRate).toHaveBeenCalledWith(0.5);
+  });
+});
+
+describe('ChordPlayer transpose', () => {
+  const label = (wrapper) => wrapper.find('.chord-player-transpose-value');
+  const buttons = (wrapper) => ({
+    down: wrapper.find('#chordPlayerTransposeDown'),
+    up: wrapper.find('#chordPlayerTransposeUp'),
+    reset: wrapper.find('#chordPlayerTransposeReset'),
+  });
+
+  it('is hidden unless the host view opts in', async () => {
+    const wrapper = await mountPlayer({ showDiagrams: true });
+    expect(wrapper.find('#chordPlayerTransposeUp').exists()).toBe(false);
+  });
+
+  it('transposes timeline and diagram labels together', async () => {
+    const wrapper = await mountPlayer({ showDiagrams: true, hasTranspose: true });
+    await buttons(wrapper).up.trigger('click');
+    await buttons(wrapper).up.trigger('click');
+
+    expect(label(wrapper).text()).toBe('+2');
+    const diagrams = wrapper.findAllComponents({ name: 'ChordSvg' });
+    expect(diagrams.map((d) => d.props('chord'))).toEqual(['Bm', 'D', 'A']);
+    // The timeline blocks show the same transposed labels.
+    const blockLabels = wrapper.findAll('.chord-block-label').map((b) => b.text());
+    expect(blockLabels).toContain('Bm');
+    expect(blockLabels).not.toContain('Am');
+  });
+
+  it('shows a capo hint for downward transposes within reach of a real capo', async () => {
+    const wrapper = await mountPlayer({ hasTranspose: true });
+    await buttons(wrapper).down.trigger('click');
+    await buttons(wrapper).down.trigger('click');
+    expect(wrapper.find('.chord-player-capo-hint').text()).toBe('pages.playAlong.capoHint:2');
+  });
+
+  it('hides the capo hint when the equivalent fret is impractical', async () => {
+    const wrapper = await mountPlayer({ hasTranspose: true });
+    await buttons(wrapper).up.trigger('click'); // +1 → capo 11
+    expect(wrapper.find('.chord-player-capo-hint').exists()).toBe(false);
+  });
+
+  it('resets to the original key and clamps at ±11', async () => {
+    const wrapper = await mountPlayer({ hasTranspose: true });
+    const { up } = buttons(wrapper);
+    for (let i = 0; i < 15; i += 1) {
+      // eslint-disable-next-line no-await-in-loop
+      await up.trigger('click');
+    }
+    expect(label(wrapper).text()).toBe('+11');
+    expect(up.attributes('disabled')).toBeDefined();
+
+    await buttons(wrapper).reset.trigger('click');
+    expect(label(wrapper).text()).toBe('0');
+    expect(wrapper.find('#chordPlayerTransposeReset').exists()).toBe(false);
+  });
+
+  it('drops any transpose offset when a different song loads', async () => {
+    const wrapper = await mountPlayer({ showDiagrams: true, hasTranspose: true });
+    await buttons(wrapper).up.trigger('click');
+    expect(label(wrapper).text()).toBe('+1');
+
+    await wrapper.setProps({ videoUrl: 'https://youtu.be/XYZ123def45' });
+    expect(label(wrapper).text()).toBe('0');
   });
 });

--- a/tests/unit/chordSvg.test.js
+++ b/tests/unit/chordSvg.test.js
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi } from 'vitest';
+import { mount } from '@vue/test-utils';
+
+vi.mock('vue-i18n', () => ({ useI18n: () => ({ t: (key) => key }) }));
+
+import ChordSvg from '@/components/ChordSvg.vue';
+
+// The chord database is imported asynchronously inside the component; wait
+// until either the diagram svg or the fallback tile has rendered.
+async function mountAndSettle(props) {
+  const wrapper = mount(ChordSvg, { props });
+  await vi.waitFor(() => {
+    if (!wrapper.find('svg').exists() && !wrapper.find('.chord-svg-fallback').exists()) {
+      throw new Error('not rendered yet');
+    }
+  });
+  return wrapper;
+}
+
+describe('ChordSvg', () => {
+  it('renders a fingering diagram for a known chord', async () => {
+    const wrapper = await mountAndSettle({ chord: 'Am' });
+    expect(wrapper.find('svg').exists()).toBe(true);
+    expect(wrapper.find('.chord-title').text()).toBe('Am');
+    expect(wrapper.find('.chord-svg-fallback').exists()).toBe(false);
+  });
+
+  it('renders slash chords using the base chord fingering, keeping the full name', async () => {
+    const wrapper = await mountAndSettle({ chord: 'D/F#' });
+    expect(wrapper.find('svg').exists()).toBe(true);
+    expect(wrapper.find('.chord-title').text()).toBe('D/F#');
+  });
+
+  it('renders suffixes that previously fell through the mapping', async () => {
+    const wrapper = await mountAndSettle({ chord: 'Asus4' });
+    expect(wrapper.find('svg').exists()).toBe(true);
+    expect(wrapper.find('.chord-title').text()).toBe('Asus4');
+  });
+
+  it('renders a name-only tile instead of nothing for unknown chords', async () => {
+    const wrapper = await mountAndSettle({ chord: 'Cweird9' });
+    expect(wrapper.find('svg').exists()).toBe(false);
+    const fallback = wrapper.find('.chord-svg-fallback');
+    expect(fallback.exists()).toBe(true);
+    expect(fallback.text()).toBe('Cweird9');
+    expect(fallback.attributes('title')).toBe('chordDiagram.unavailable');
+  });
+
+  it('renders the fallback for unparseable labels too', async () => {
+    const wrapper = await mountAndSettle({ chord: 'N.C.' });
+    expect(wrapper.find('.chord-svg-fallback').text()).toBe('N.C.');
+  });
+
+  it('still supports the explicit root/suffix API used by the chords library', async () => {
+    const wrapper = await mountAndSettle({ root: 'C', suffix: 'major' });
+    expect(wrapper.find('svg').exists()).toBe(true);
+    expect(wrapper.find('.chord-title').text()).toBe('C');
+  });
+
+  it('renders ukulele diagrams with the instrument-specific root spelling', async () => {
+    const wrapper = await mountAndSettle({ chord: 'C#m', instrument: 'ukulele' });
+    expect(wrapper.find('svg').exists()).toBe(true);
+    expect(wrapper.find('.chord-title').text()).toBe('C#m');
+  });
+});


### PR DESCRIPTION
## Summary

Four improvements from the chord-generator feature review:

**Playback speed (ChordPlayer)** — 0.5× / 0.75× / 1× switcher wired to the YouTube player via `setPlaybackRate`. The chosen speed survives player rebuilds and `loadVideoById` (which resets the rate on some clients). Available in both the generator view and SongView play-along.

**Transpose + capo (ChordPlayer, opt-in)** — ±11-semitone control that re-labels the scrolling timeline and the diagram panel together, keeping suffixes and transposing slash basses correctly (flat roots stay flat-spelled). When the equivalent capo sits on a practical fret (1–7), a hint shows how to play the transposed shapes and still sound in the original key. The offset resets when a different song loads. Enabled on the generated-song view only — SongView has its own body-level transpose, and a second one would fight it.

**Chord diagram fallbacks (ChordSvg)** — slash chords like `D/F#` now render the base chord's fingering with the full name displayed, and chords the database doesn't know render a name-only tile instead of silently vanishing from diagram grids. Parsing/spelling/transposition extracted to a pure `src/utils/chordName.js` module.

**Submission allowance (submit view)** — the status box now shows remaining daily submissions (from the new `GET /me/chordgen-songs/limit`); when exhausted it becomes a warning with the reset time and the submit button disables itself. A 429 surfaces the reset time from the enriched response. Requires the matching akordi/portal-api PR (works degraded without it: allowance line simply absent).

Also: the list view only renders rating stars once a song actually has ratings, and the dead `rating.none` key is removed from all four locales. New locale keys added to lv/ee/es/lt.

## Testing

- `bun run lint`, `bun run test` (82 tests — 37 new/updated across chordName utils, ChordSvg render paths, ChordPlayer speed/transpose with a fake YT player, and the allowance/429 flows), and `bun run build` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RnF4w9DcbKw9WaqEYoDMED

---
_Generated by [Claude Code](https://claude.ai/code/session_01RnF4w9DcbKw9WaqEYoDMED)_