### PR TITLE
Visual polish from screenshot review of the practice controls

### DIFF
--- a/src/components/ChordPlayer.vue
+++ b/src/components/ChordPlayer.vue
@@ -10,11 +10,11 @@
  */
 import { computed, onBeforeUnmount, ref, shallowRef, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
-import { LxButton, LxContentSwitcher } from '@dativa-lv/lx-ui';
+import { LxButton, LxValuePicker } from '@dativa-lv/lx-ui';
 
 import ChordSvg from '@/components/ChordSvg.vue';
 import { activeSegmentIndex, youtubeId } from '@/utils/chordSync';
-import { capoForOffset, transposeChord } from '@/utils/chordName';
+import { capoForOffset, isNoChord, transposeChord } from '@/utils/chordName';
 
 const { t: $t } = useI18n();
 
@@ -120,12 +120,13 @@ const displaySegments = computed(() => {
 // Diagram panel data: every distinct chord of the song, in order of first
 // appearance. Deliberately NOT synced to the playhead — the timeline already
 // highlights the current chord, and a second moving highlight reads as
-// fragmented; the panel is a static fingering reference.
+// fragmented; the panel is a static fingering reference. No-chord markers
+// (N/N.C.) belong on the timeline as gaps, not in the fingering panel.
 const uniqueChords = computed(() => {
   const seen = new Set();
   const out = [];
   displaySegments.value.forEach((seg) => {
-    if (seg.label && !seen.has(seg.label)) {
+    if (seg.label && !isNoChord(seg.label) && !seen.has(seg.label)) {
       seen.add(seg.label);
       out.push(seg.label);
     }
@@ -344,10 +345,15 @@ onBeforeUnmount(() => {
       <!-- Practice controls: playback speed for everyone; transpose (with a
            capo hint) only where the host view opts in. -->
       <div class="chord-player-controls">
+        <!-- horizontal LxValuePicker, not LxContentSwitcher: the switcher
+             collapses labels to bare index numbers below 800px viewport
+             width, which turns speeds into meaningless "1 2 3" on phones. -->
         <div class="chord-player-control">
           <span class="lx-label" id="chordPlayerSpeedLabel">{{ $t('pages.playAlong.speed') }}</span>
-          <LxContentSwitcher
+          <LxValuePicker
             id="chordPlayerSpeedSwitcher"
+            variant="tags"
+            selection-kind="single"
             :items="speedOptions"
             v-model="speedId"
             label-id="chordPlayerSpeedLabel"
@@ -396,8 +402,13 @@ onBeforeUnmount(() => {
       class="chord-player-diagrams"
       :aria-label="$t('pages.chordsLibrary.instrument')"
     >
-      <LxContentSwitcher
+      <!-- Dropdown rather than a content switcher: the side panel is too
+           narrow for three instrument names, and a switcher degrades to
+           truncated labels there. -->
+      <LxValuePicker
         id="chordPlayerInstrumentSwitcher"
+        variant="dropdown"
+        selection-kind="single"
         :items="instrumentOptions"
         :model-value="instrument"
         @update:model-value="(value) => emit('update:instrument', value)"

--- a/src/utils/chordName.js
+++ b/src/utils/chordName.js
@@ -28,6 +28,17 @@ const SHARP_SCALE = ['C', 'C#', 'D', 'D#', 'E', 'F', 'F#', 'G', 'G#', 'A', 'A#',
 const FLAT_SCALE = ['C', 'Db', 'D', 'Eb', 'E', 'F', 'Gb', 'G', 'Ab', 'A', 'Bb', 'B'];
 
 /**
+ * Whether a timeline label marks "no chord" (rests/noise between chords) —
+ * chord recognisers emit these as N / NC / N.C. They belong on the timeline
+ * as gaps but never in a fingering panel.
+ * @param {string} label
+ * @returns {boolean}
+ */
+export function isNoChord(label) {
+  return typeof label === 'string' && /^n\.?c?\.?$/i.test(label.trim());
+}
+
+/**
  * Split a chord label into root, suffix, and optional slash bass note.
  * Examples: 'Am7' → {root:'A', suffix:'m7', bass:null};
  * 'D/F#' → {root:'D', suffix:'', bass:'F#'}.

--- a/tests/unit/chordName.test.js
+++ b/tests/unit/chordName.test.js
@@ -5,6 +5,7 @@ import {
   capoForOffset,
   dbSuffix,
   dbRoot,
+  isNoChord,
 } from '@/utils/chordName';
 
 describe('parseChordName', () => {
@@ -121,5 +122,22 @@ describe('dbRoot', () => {
   it('leaves natural roots alone', () => {
     expect(dbRoot('C', 'guitar')).toBe('C');
     expect(dbRoot('G', 'ukulele')).toBe('G');
+  });
+});
+
+describe('isNoChord', () => {
+  it('recognises the common no-chord spellings', () => {
+    expect(isNoChord('N')).toBe(true);
+    expect(isNoChord('NC')).toBe(true);
+    expect(isNoChord('N.C.')).toBe(true);
+    expect(isNoChord('n.c.')).toBe(true);
+    expect(isNoChord(' N ')).toBe(true);
+  });
+
+  it('leaves real chords and garbage alone', () => {
+    expect(isNoChord('Am')).toBe(false);
+    expect(isNoChord('C')).toBe(false);
+    expect(isNoChord('')).toBe(false);
+    expect(isNoChord(null)).toBe(false);
   });
 });

--- a/tests/unit/chordPlayer.test.js
+++ b/tests/unit/chordPlayer.test.js
@@ -2,9 +2,9 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { mount } from '@vue/test-utils';
 
 vi.mock('@dativa-lv/lx-ui', () => ({
-  LxContentSwitcher: {
-    name: 'LxContentSwitcher',
-    props: ['items', 'modelValue'],
+  LxValuePicker: {
+    name: 'LxValuePicker',
+    props: ['items', 'modelValue', 'variant'],
     emits: ['update:modelValue'],
     template: '<div />',
   },
@@ -77,8 +77,8 @@ async function mountPlayer(props = {}) {
 
 const speedSwitcher = (wrapper) =>
   wrapper
-    .findAllComponents({ name: 'LxContentSwitcher' })
-    .find((c) => c.props('items')?.some((i) => i.id === '0.5'));
+    .findAllComponents({ name: 'LxValuePicker' })
+    .find((c) => c.props('variant') === 'tags');
 
 describe('ChordPlayer chord diagram panel', () => {
   it('is hidden by default so existing usages are unchanged', async () => {
@@ -102,10 +102,11 @@ describe('ChordPlayer chord diagram panel', () => {
     const diagrams = wrapper.findAllComponents({ name: 'ChordSvg' });
     expect(diagrams.every((d) => d.props('instrument') === 'ukulele')).toBe(true);
 
-    const switcher = wrapper
-      .findAllComponents({ name: 'LxContentSwitcher' })
-      .find((c) => c.props('modelValue') === 'ukulele');
-    switcher.vm.$emit('update:modelValue', 'guitar');
+    const dropdown = wrapper
+      .findAllComponents({ name: 'LxValuePicker' })
+      .find((c) => c.props('variant') === 'dropdown');
+    expect(dropdown.props('modelValue')).toBe('ukulele');
+    dropdown.vm.$emit('update:modelValue', 'guitar');
     expect(wrapper.emitted('update:instrument')).toEqual([['guitar']]);
   });
 
@@ -115,6 +116,19 @@ describe('ChordPlayer chord diagram panel', () => {
       segments: [{ start: 0, end: 2, label: '' }],
     });
     expect(wrapper.find('.chord-player-diagrams').exists()).toBe(false);
+  });
+
+  it('keeps no-chord markers out of the fingering panel', async () => {
+    const wrapper = await mountPlayer({
+      showDiagrams: true,
+      segments: [
+        { start: 0, end: 2, label: 'Am' },
+        { start: 2, end: 4, label: 'N' },
+        { start: 4, end: 6, label: 'C' },
+      ],
+    });
+    const diagrams = wrapper.findAllComponents({ name: 'ChordSvg' });
+    expect(diagrams.map((d) => d.props('chord'))).toEqual(['Am', 'C']);
   });
 });
 


### PR DESCRIPTION
## Summary

Follow-up to #59 after driving the built app in headless Chromium at desktop (1440px) and mobile (390px) widths and reviewing screenshots:

- **No-chord markers (N / N.C.) no longer get a fingering tile.** The generator emits `N` segments for rests; the new fallback tile dutifully rendered them as a big dashed "N" in the diagram panel. They stay on the timeline as gaps but are now filtered from the panel (`isNoChord` helper + tests).
- **Speed control → tags-variant `LxValuePicker`.** `LxContentSwitcher` collapses its labels to bare index numbers below 800px viewport width, which turned the speeds into a meaningless "1 2 3" on every phone. The tags variant keeps "0.5× / 0.75× / 1×" readable at all widths.
- **Instrument picker → dropdown-variant `LxValuePicker`.** Three instrument names don't fit the 18rem diagram side panel as a switcher and truncated to "Ģit… / Uku… / Barit…".

## Testing

- `bun run lint`, `bun run test` (85 tests, including new no-chord filtering coverage), and `bun run build` pass.
- Re-ran the headless-Chromium visual pass after the fixes: desktop and mobile song view, transpose ±2 with capo hint, ukulele switch, speed selection, list view, and both submit-allowance states all render correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RnF4w9DcbKw9WaqEYoDMED

---
_Generated by [Claude Code](https://claude.ai/code/session_01RnF4w9DcbKw9WaqEYoDMED)_