### PR TITLE
Add YouTube link field to public song edit form

### DIFF
--- a/src/locales/ee.json
+++ b/src/locales/ee.json
@@ -684,7 +684,8 @@
         "validation": "Palun täitke väljad"
     },
     "validations": {
-        "required": "See väli on kohustuslik"
+        "required": "See väli on kohustuslik",
+        "url": "Vigane link"
     },
     "accessibilitySettings": {
         "title": "Juurdepääsetavuse seaded",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -684,7 +684,8 @@
         "validation": "Por favor, complete los campos"
     },
     "validations": {
-        "required": "Este campo es obligatorio"
+        "required": "Este campo es obligatorio",
+        "url": "Enlace no válido"
     },
     "accessibilitySettings": {
         "title": "Configuración de accesibilidad",

--- a/src/locales/lt.json
+++ b/src/locales/lt.json
@@ -684,7 +684,8 @@
         "validation": "Prašome užpildyti laukus"
     },
     "validations": {
-        "required": "Šis laukas yra privalomas"
+        "required": "Šis laukas yra privalomas",
+        "url": "Netinkama nuoroda"
     },
     "accessibilitySettings": {
         "title": "Prieinamumo nustatymai",

--- a/src/locales/lv.json
+++ b/src/locales/lv.json
@@ -684,7 +684,8 @@
         "validation": "Lūdzu aizpildiet laukus"
     },
     "validations": {
-        "required": "Šis lauks ir obligāts"
+        "required": "Šis lauks ir obligāts",
+        "url": "Nederīga saite"
     },
     "accessibilitySettings": {
         "title": "Piekļūstamības iestatījumi",

--- a/src/views/SongEdit.vue
+++ b/src/views/SongEdit.vue
@@ -15,6 +15,7 @@ import { useRoute, useRouter } from 'vue-router';
 import akordiService from '@/services/akordiService';
 import useNotifyStore from '@/stores/useNotifyStore';
 import useViewStore from '@/stores/useViewStore';
+import { youtubeId } from '@/utils/chordSync';
 import useVuelidate from '@vuelidate/core';
 import * as validations from '@vuelidate/validators';
 
@@ -36,6 +37,7 @@ const item = ref({
   tagsIds: [],
   composersIds: [],
   poetsIds: [],
+  youtubeLink: '',
 });
 const props = defineProps({
   isNew: {
@@ -56,6 +58,11 @@ const loadCopyFrom = async () => {
     item.value.title = resp.data.title;
     item.value.id = resp.data.id;
     item.value.mainArtistId = String(resp.data.mainArtist.id);
+    // youtubeLink is stored as a bare 11-char video id, so expand it to a
+    // watch URL for editing.
+    item.value.youtubeLink = resp.data.youtubeLink
+      ? `https://www.youtube.com/watch?v=${resp.data.youtubeLink}`
+      : '';
     item.value.composersIds = resp.data.composers?.map((i) => String(i.id)) || [];
     item.value.poetsIds = resp.data.poets?.map((i) => String(i.id)) || [];
     item.value.performersIds = resp.data.performers?.map((i) => String(i.id)) || [];
@@ -107,12 +114,14 @@ const loadCopyFrom = async () => {
 };
 
 const required = withI18nMessage(validations.required);
+const url = withI18nMessage(validations.url);
 const rules = {
   title: { required },
   body: { required },
   mainArtistId: { required },
   composers: {},
   poets: {},
+  youtubeLink: { url },
 };
 
 const v = useVuelidate(rules, item);
@@ -147,6 +156,13 @@ function mapTag(id) {
   return tags.value.find((tag) => tag.id === +id);
 }
 
+// The API stores youtube_link as a bare video id, so strip the pasted URL
+// down before submitting. A value youtubeId() can't parse is sent as typed.
+function toYoutubeId(link) {
+  const trimmed = (link || '').trim();
+  return youtubeId(trimmed) || trimmed;
+}
+
 async function actionClicked(actionName) {
   if (actionName === 'save') {
     const isFormCorrect = await v.value.$validate();
@@ -165,6 +181,7 @@ async function actionClicked(actionName) {
         poets: item.value.poetsIds.map((i) => mapArtistFromId(i)),
         composers: item.value.composersIds.map((i) => mapArtistFromId(i)),
         tags: item.value.tagsIds.map((i) => mapTag(i)),
+        youtubeLink: toYoutubeId(item.value.youtubeLink),
       };
 
       await akordiService.saveEdit(edit);
@@ -319,6 +336,18 @@ onUnmounted(() => {
         variant="dropdown"
         :preloaded-items="preloadedTags"
       />
+    </LxRow>
+    <LxRow :label="$t('song.youtubeLink')">
+      <LxTextInput
+        id="youtubeInput"
+        v-model="item.youtubeLink"
+        :invalid="v.youtubeLink.$error"
+        :invalidation-message="v.youtubeLink.$error ? v.youtubeLink.$errors[0].$message : ''"
+      />
+      <br />
+      <a v-if="item.youtubeLink" :href="item.youtubeLink" target="_blank">
+        {{ item.youtubeLink }}
+      </a>
     </LxRow>
     <LxRow :label="$t('song.body')" :required="true" inputId="bodyInput">
       <template #info>{{ $t('song.bodyTooltip') }}</template>


### PR DESCRIPTION
## Summary

Adds a YouTube link input to the public song submit/edit form (`SongEdit.vue`), so users can suggest a video when submitting a new song or an edit.

- When editing an existing song, the stored bare video id is expanded to a full `https://www.youtube.com/watch?v=...` URL for display, mirroring the admin editor.
- Before submission the pasted URL is stripped back down to the bare video id via the existing `youtubeId()` util (supports `watch?v=`, `youtu.be/`, `/embed/`, `/shorts/`), matching how `youtube_link` is stored in the database.
- The field is optional and validated with the vuelidate `url` validator; a new `validations.url` message was added to all four locales (lv, lt, ee, es).
- A clickable preview link is shown under the input, same as in the admin song editor.

The API already accepts `youtubeLink` on `POST /api/v2/edits`, so no backend changes are needed. The companion admin-portal PR surfaces the submitted change in the edit review view.

## Testing

- `bun run lint` — clean
- `bun run test` — 85 tests pass
- `bun run build` — succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SipvtdvAUqaRbJaXzi96GD

---
_Generated by [Claude Code](https://claude.ai/code/session_01SipvtdvAUqaRbJaXzi96GD)_